### PR TITLE
add settings hash to cache_key and add API tests

### DIFF
--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -11,7 +11,7 @@
       $path = $headers->pathname;
       $lang = $headers->lang();
       $body_hash = md5($original_content);
-      $settings_hash = md5(serialize($store->settings));
+      $settings_hash = md5(serialize(asort($store->settings)));
       $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
       return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;
     }

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -46,7 +46,7 @@
       $path = $headers->pathname;
       $lang = $headers->lang();
       $body_hash = md5($content);
-      $settings_hash = md5(serialize($store->settings));
+      $settings_hash = md5(serialize(asort($store->settings)));
       $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
 
       return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;


### PR DESCRIPTION
Add settings hash to cache key so that path is not unique when user change settings. For instance, if user changes URL pattern setting, cached version will be invalid because links have been changed based on former URL pattern.