### PR TITLE
  always remove language from HTTP_REFERER

### DIFF
--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -262,6 +262,8 @@
     public function requestOut($includePath, $defLang=null) {
       if ($defLang === null)
         $defLang = $this->store->settings['default_lang'];
+      if (isset($this->_env['HTTP_REFERER']))
+        $this->_env['HTTP_REFERER'] = $this->removeLang($this->_env['HTTP_REFERER']);
       switch ($this->store->settings['url_pattern_name']){
         case 'query':
           if (isset($this->_env['REQUEST_URI'])) {
@@ -278,8 +280,6 @@
           }
           $this->_env['HTTP_HOST'] = $this->removeLang($this->_env['HTTP_HOST']);
           $this->_env['SERVER_NAME'] = $this->removeLang($this->_env['SERVER_NAME']);
-          if (isset($this->_env['HTTP_REFERER']))
-            $this->_env['HTTP_REFERER'] = $this->removeLang($this->_env['HTTP_REFERER']);
           break;
         case 'path':
         default:

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -931,4 +931,60 @@ class HeadersTest extends PHPUnit_Framework_TestCase {
     return $env;
   }
 
+  public function testRequestOutSubdomainPatternWithHTTP_REFERER () {
+    $includePath = '/dummy';
+
+    $store = $this->createStore();
+    $store->settings['url_pattern_name'] = 'subdomain';
+    $store->settings['url_pattern_reg'] = "^(?P<lang>[^.]+)\.";
+
+    $env = $this->getEnv();
+    $env['HTTP_REFERER'] = 'ja.minimaltech.co';
+    $env['REQUEST_URI'] = $includePath;
+    $_SERVER['REQUEST_URI'] = $env['REQUEST_URI'];
+
+    $headers = new Headers($env, $store);
+
+    $this->assertEquals('ja', $headers->pathLang());
+    $headers->requestOut($includePath);
+    $this->assertEquals('minimaltech.co', $env['HTTP_REFERER']);
+  }
+
+  public function testRequestOutPathPatternWithHTTP_REFERER () {
+    $includePath = '/ja/dummy';
+
+    $store = $this->createStore();
+    $store->settings['url_pattern_name'] = 'path';
+    $store->settings['url_pattern_reg'] = '\/(?P<lang>[^\/.]+)(\/|\?|$)';
+
+    $env = $this->getEnv();
+    $env['HTTP_REFERER'] = 'minimaltech.co/ja';
+    $env['REQUEST_URI'] = $includePath;
+    $_SERVER['REQUEST_URI'] = $env['REQUEST_URI'];
+
+    $headers = new Headers($env, $store);
+
+    $this->assertEquals('ja', $headers->pathLang());
+    $headers->requestOut($includePath);
+    $this->assertEquals('minimaltech.co/', $env['HTTP_REFERER']);
+  }
+
+  public function testRequestOutQueryPatternWithHTTP_REFERER () {
+    $includePath = '/dummy?wovn=ja';
+
+    $store = $this->createStore();
+    $store->settings['url_pattern_name'] = 'query';
+    $store->settings['url_pattern_reg'] = '((\?.*&)|\?)wovn=(?P<lang>[^&]+)(&|$)';
+
+    $env = $this->getEnv();
+    $env['HTTP_REFERER'] = 'minimaltech.co/?wovn=ja';
+    $env['REQUEST_URI'] = $includePath;
+    $_SERVER['REQUEST_URI'] = $env['REQUEST_URI'];
+
+    $headers = new Headers($env, $store);
+
+    $this->assertEquals('ja', $headers->pathLang());
+    $headers->requestOut($includePath);
+    $this->assertEquals('minimaltech.co/', $env['HTTP_REFERER']);
+  }
 }


### PR DESCRIPTION
### Purpose/goal of Pull Request (Issue #)
Remove language code from `HTTP_REFERER`.

### Comments
Some frameworks such as EC-Cube use `HTTP_REFERER` to create links (e.g. "Back" button).
WovnPHP is not expecting to see any lang code in the HTML it is intercepted so it is adding a second code.

HTTP_REFERER should be not contain language information when used by user's code, so I changed `Headers.requestOut()` to always remove language code from the `HTTP_REFERER`.

I did not change `SwapVals.swapVals()` to first remove language code from links because it could create new bugs and we cannot guaranty that user does not have a subdirectory with same name as a lang code.
