### PR TITLE
Stop using simple_html_dom because of memory leak issue

### DIFF
--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -60,7 +60,7 @@ class HtmlConverter
    */
   private function insertSnippet($html)
   {
-    $snippet_regex = "/<script[^<]*src=[^<]*j\.[^<]*wovn\.io[^<]*><\/script>/iU";
+    $snippet_regex = "/<script[^>]*src=[^>]*j\.[^ '\">]*wovn\.io[^>]*><\/script>/i";
     $html = $this->removeTagFromHtmlByRegex($html, $snippet_regex);
 
     $snippet_code = $this->buildSnippetCode();

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -99,8 +99,9 @@ class HtmlConverter
     $default_lang = $this->store->settings['default_lang'];
     $url_pattern = $this->store->settings['url_pattern_name'];
     $lang_code_aliases_json = json_encode($this->store->settings['custom_lang_aliases']);
+    $data_wovnio = htmlentities("key=$token&backend=true&currentLang=$current_lang&defaultLang=$default_lang&urlPattern=$url_pattern&langCodeAliases=$lang_code_aliases_json&version=WOVN.php");
 
-    return "<script src='//j.wovn.io/1' data-wovnio='key=$token&backend=true&currentLang=$current_lang&defaultLang=$default_lang&urlPattern=$url_pattern&langCodeAliases=$lang_code_aliases_json&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>";
+    return "<script src=\"//j.wovn.io/1\" data-wovnio=\"$data_wovnio\" data-wovnio-type=\"backend_without_api\" async></script>";
   }
 
   /**

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -67,7 +67,7 @@ class HtmlConverter
 
     $token = $this->token;
     $snippet_code = "<script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>";
-    $parent_tags = array('<head>', '<body>', '<html>');
+    $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
     return $this->insertAfterTag($parent_tags, $html, $snippet_code);
   }
@@ -76,7 +76,7 @@ class HtmlConverter
   {
     foreach ($tag_names as $tag_name) {
       if (preg_match($tag_name, $html, $matches, PREG_OFFSET_CAPTURE)) {
-        return substr_replace($html, $insert_str, $matches[0][1] + strlen($tag_name) - 1, 0);
+        return substr_replace($html, $insert_str, $matches[0][1] + strlen($matches[0][0]), 0);
       }
     }
   }
@@ -114,7 +114,7 @@ class HtmlConverter
       array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso639_1Normalization($lang_code) . '" href="' . $href . '">');
     }
 
-    $parent_tags = array('<head>', '<body>', '<html>');
+    $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
     return $this->insertAfterTag($parent_tags, $html, implode('', $hreflangTags));
   }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -29,7 +29,7 @@ class HtmlConverter
    * @param Store $store
    * @param Headers $headers
    */
-  public function __construct($html, $encoding, $token, $store = null, $headers = null)
+  public function __construct($html, $encoding, $token, $store, $headers)
   {
     $this->html = $html;
     $this->encoding = $encoding;
@@ -56,7 +56,7 @@ class HtmlConverter
    * Insert wovn's snippet to ensure snippet is always inserted.
    * When snippet is always inserted, do nothing
    *
-   * @param simple_html_dom_node $html
+   * @param string $html
    */
   private function insertSnippet($html)
   {
@@ -65,8 +65,7 @@ class HtmlConverter
       return;
     }
 
-    $token = $this->token;
-    $snippet_code = "<script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>";
+    $snippet_code = $this->buildSnippetCode();
     $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
     return $this->insertAfterTag($parent_tags, $html, $snippet_code);
@@ -81,10 +80,21 @@ class HtmlConverter
     }
   }
 
+  private function buildSnippetCode()
+  {
+    $token = $this->token;
+    $current_lang = $this->headers->lang();
+    $default_lang = $this->store->settings['default_lang'];
+    $url_pattern = $this->store->settings['url_pattern_name'];
+    $lang_code_aliases_json = json_encode($this->store->settings['custom_lang_aliases']);
+//    $snippet_code = "<script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>";
+    return "<script src='//j.wovn.io/1' data-wovnio='key=$token&backend=true&currentLang=$current_lang&defaultLang=$default_lang&urlPattern=$url_pattern&langCodeAliases=$lang_code_aliases_json&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>";
+  }
+
   /**
    * Insert hreflang tags for all supported_langs
    *
-   * @param simple_html_dom_node $dom
+   * @param string $html
    */
   private function insertHreflangTags($html)
   {

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -26,7 +26,7 @@
       $token = $store->settings['project_token'];
       $converter = new HtmlConverter($original_content, $encoding, $token, $store, $headers);
       if (self::makeAPICall($store, $headers)) {
-        list($converted_html, $marker) = $converter->convertToAppropriateForApiBody();
+        list($converted_html) = $converter->convertToAppropriateForApiBody();
         $timeout = $store->settings['api_timeout'];
         $data = array(
           'url' => $headers->url,
@@ -42,13 +42,13 @@
 
         try {
           $translation_response = json_decode(RequestHandlerFactory::get()->sendRequest('POST', $api_url, $data, $timeout), true);
-          $translated_content = $marker->revert($translation_response['body']);
+          $translated_content = $translation_response['body'];
         } catch (\Exception $e) {
           error_log('****** WOVN++ LOGGER :: Failed to get translated content: ' . $e->getMessage() . ' ******');
         }
       }
       else {
-        list($converted_html, $marker) = $converter->convertToAppropriateForApiBody(false);
+        list($converted_html) = $converter->convertToAppropriateForApiBody();
         $translated_content = $converted_html;
       }
 

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -26,7 +26,8 @@
       $token = $store->settings['project_token'];
       $converter = new HtmlConverter($original_content, $encoding, $token, $store, $headers);
       if (self::makeAPICall($store, $headers)) {
-        list($converted_html) = $converter->convertToAppropriateForApiBody();
+//        list($converted_html) = $converter->convertToAppropriateForApiBody();
+        $converted_html = $original_content;
         $timeout = $store->settings['api_timeout'];
         $data = array(
           'url' => $headers->url,
@@ -48,7 +49,7 @@
         }
       }
       else {
-        list($converted_html) = $converter->convertToAppropriateForApiBody();
+        list($converted_html) = $converter->insertSnippetAndHreflangTags();
         $translated_content = $converted_html;
       }
 

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -24,9 +24,8 @@
 
       $encoding = $store->settings['encoding'];
       $token = $store->settings['project_token'];
-      $converter = new HtmlConverter($original_content, $encoding, $token, $store, $headers);
+
       if (self::makeAPICall($store, $headers)) {
-//        list($converted_html) = $converter->convertToAppropriateForApiBody();
         $converted_html = $original_content;
         $timeout = $store->settings['api_timeout'];
         $data = array(
@@ -49,6 +48,7 @@
         }
       }
       else {
+        $converter = new HtmlConverter($original_content, $encoding, $token, $store, $headers);
         list($converted_html) = $converter->insertSnippetAndHreflangTags();
         $translated_content = $converted_html;
       }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -347,7 +347,6 @@
       global $_GET, $_REQUEST;
 
       // get old query string
-      $oldQueryString = '';
       if (isset($this->_env['QUERY_STRING'])) {
         $oldQueryString = $this->_env['QUERY_STRING'];
       }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -120,6 +120,7 @@
 
       return $vals;
     }
+
     private function isWovnDevModeActivated($settings=null) {
       if ($settings === null) $settings = $this->settings;
 

--- a/src/wovnio/wovnphp/Url.php
+++ b/src/wovnio/wovnphp/Url.php
@@ -77,7 +77,7 @@ class Url {
             break;
           default:
             //path
-            $new_uri = preg_replace('/([^\.]*\.[^\/]*)(\/|$)/', '${1}/' . self::formatForRegExp($lang_code) . '/', $no_lang_uri, 1);
+            $new_uri = preg_replace('/([^\.]*\.[^?\/]*)(\?|\/|$)/', '${1}/' . self::formatForRegExp($lang_code) . '${2}', $no_lang_uri, 1);
         }
       }
     } else {
@@ -117,6 +117,7 @@ class Url {
         }
       }
     }
+
     return $new_uri;
   }
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -214,7 +214,7 @@
       $store->settings['default_lang'] = 'en';
 
       $html = '<html><head></head><body><h1>en</h1></body></html>';
-      $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://localhost.com/ja/t.php?wovn=en"><script src=\'//j.wovn.io/1\' data-wovnio=\'key=&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php\' data-wovnio-type=\'backend_without_api\' async></script></head><body><h1>en</h1></body></html>';
+      $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://localhost.com/ja/t.php?wovn=en"><script src="//j.wovn.io/1" data-wovnio="key=&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script></head><body><h1>en</h1></body></html>';
 
       $mock = $this->getMockAndRegister('Wovnio\Utils\RequestHandlers\CurlRequestHandler', array('sendRequest'));
       $mock->expects($this->never())->method('sendRequest');

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -214,7 +214,7 @@
       $store->settings['default_lang'] = 'en';
 
       $html = '<html><head></head><body><h1>en</h1></body></html>';
-      $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://localhost.com/ja/t.php?wovn=en"><script src=\'//j.wovn.io/1\' data-wovnio=\'key=\' data-wovnio-type=\'backend_without_api\' async></script></head><body><h1>en</h1></body></html>';
+      $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://localhost.com/ja/t.php?wovn=en"><script src=\'//j.wovn.io/1\' data-wovnio=\'key=&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php\' data-wovnio-type=\'backend_without_api\' async></script></head><body><h1>en</h1></body></html>';
 
       $mock = $this->getMockAndRegister('Wovnio\Utils\RequestHandlers\CurlRequestHandler', array('sendRequest'));
       $mock->expects($this->never())->method('sendRequest');

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -142,6 +142,7 @@
     }
 
     public function testTranslateWithWovnIgnore() {
+      $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
       $env = $this->getEnv('_path');
       list($store, $headers) = Utils::getStoreAndHeaders($env);
       $html = '<html><head></head><body><h1 wovn-ignore>en</h1>hello</body></html>';

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -78,7 +78,7 @@
       $response = '{"body":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
       $token = $store->settings['project_token'];
-      $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://localhost.com/ja/t.php?wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script></head><body><h1>en</h1></body></html>";
+      $expected_html = "<html><head></head><body><h1>en</h1></body></html>";
       $expected_data = array(
         'url' => $headers->url,
         'token' => $store->settings['project_token'],
@@ -113,7 +113,7 @@
       $html = '<html><head></head><body><h1>en</h1></body></html>';
       $response = '{"body":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
 
-      $expected_body = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://localhost.com/ja/t.php?wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script></head><body><h1>en</h1></body></html>";
+      $expected_body = $html;
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
       $expected_data = array(
         'url' => $headers->url,
@@ -181,8 +181,8 @@
       $html = '<html><head></head><body><h1>en</h1></body></html>';
       $response = '{"missingBodyError":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
-      $token = $store->settings['project_token'];
-      $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://localhost.com/ja/t.php?wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script></head><body><h1>en</h1></body></html>";
+
+      $expected_html = $html;
       $expected_data = array(
         'url' => $headers->url,
         'token' => $store->settings['project_token'],
@@ -234,7 +234,7 @@
       $html = '<html><head></head><body><h1>en</h1></body></html>';
 
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
-      $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://localhost.com/en/ja/t.php\"><script src='//j.wovn.io/1' data-wovnio='key=' data-wovnio-type='backend_without_api' async></script></head><body><h1>en</h1></body></html>";
+      $expected_html = $html;
       $response = '{"body":"<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http:\/\/localhost.com\/ja\/t.php?wovn=en\"><script src=\'\/\/j.wovn.io\/1\' data-wovnio=\'key=\' data-wovnio-type=\'backend_without_api\' async><\/script><\/head><body><h1>fr<\/h1><\/body><\/html>"}';
 
       $expected_data = array(

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -58,6 +58,21 @@ class UrlTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($uri, Url::addLangCode($uri, $store, $lang, $headers));
   }
 
+  public function testAddLangCodeAbsoluteUrWithPathPattern()
+  {
+    $req_uri = "http://localhost.com?lang=zh-CHS";
+    $expected_uri = 'http://localhost.com/en?lang=zh-CHS';
+    $lang = 'en';
+    $pattern = 'path';
+
+    list($store, $env, $headers) = $this->getStarted($pattern, array(
+      'REQUEST_URI' => $req_uri
+    ));
+
+    echo Url::addLangCode($req_uri, $store, $lang, $headers);
+    $this->assertEquals($expected_uri, Url::addLangCode($req_uri, $store, $lang, $headers));
+  }
+
   public function testAddLangCodeRelativePathWithQueryPattern () {
     $uri = '/index.php';
     $lang = 'fr';

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -69,7 +69,6 @@ class UrlTest extends PHPUnit_Framework_TestCase {
       'REQUEST_URI' => $req_uri
     ));
 
-    echo Url::addLangCode($req_uri, $store, $lang, $headers);
     $this->assertEquals($expected_uri, Url::addLangCode($req_uri, $store, $lang, $headers));
   }
 

--- a/test/fixtures/basic_html/insert_hreflang_body.html
+++ b/test/fixtures/basic_html/insert_hreflang_body.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="container">
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_body_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_body_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 <p>Fake body</p>
 </body>
 </html>

--- a/test/fixtures/basic_html/insert_hreflang_body_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_body_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 <p>Fake body</p>
 </body>
 </html>

--- a/test/fixtures/basic_html/insert_hreflang_body_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_body_expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/custom_en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases={"en":"custom_en","zh-CHS":"custom_simple"}&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/custom_en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;custom_en&quot;,&quot;zh-CHS&quot;:&quot;custom_simple&quot;}&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 </head>
 <body>
 </body>

--- a/test/fixtures/basic_html/insert_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/custom_en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/custom_en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases={"en":"custom_en","zh-CHS":"custom_simple"}&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 </head>
 <body>
 </body>

--- a/test/fixtures/basic_html/insert_hreflang_head_style.html
+++ b/test/fixtures/basic_html/insert_hreflang_head_style.html
@@ -1,0 +1,6 @@
+<html>
+<head class="display:none"><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
+<body>
+<p>Lorem ipsum</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
@@ -1,0 +1,6 @@
+<html>
+<head class="display:none"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
+<body>
+<p>Lorem ipsum</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
@@ -1,5 +1,5 @@
 <html>
-<head class="display:none"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
+<head class="display:none"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
 <body>
 <p>Lorem ipsum</p>
 </body>

--- a/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_head_style_expected.html
@@ -1,5 +1,5 @@
 <html>
-<head class="display:none"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
+<head class="display:none"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script><link rel="stylesheet" src="fake.css"></head>
 <body>
 <p>Lorem ipsum</p>
 </body>

--- a/test/fixtures/basic_html/insert_hreflang_html.html
+++ b/test/fixtures/basic_html/insert_hreflang_html.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html lang="en">
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_html_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_html_expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html lang="en"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_html_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_html_expected.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<html lang="en"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<html lang="en"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 </html>

--- a/test/fixtures/basic_html/insert_hreflang_html_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_html_expected.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<html lang="en"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<html lang="en"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 </html>

--- a/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes.html
+++ b/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="container">
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=path&langCodeAliases={"zh-CHS":"custom_simple"}&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;zh-CHS&quot;:&quot;custom_simple&quot;}&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 <p>Fake body</p>
 </body>
 </html>

--- a/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html
+++ b/test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="container"><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/custom_simple/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=path&langCodeAliases={"zh-CHS":"custom_simple"}&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_snippet_when_already_exist.html
+++ b/test/fixtures/basic_html/insert_snippet_when_already_exist.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><script src="//j.wovn.io:3000/1" data-wovnio="key=4tok3n" async></script><script type="text/javascript" src="fake.js"></script><script src="//j.dev-wovn.io:3000/1" data-wovnio="key=sLz3ob" async></script></head>
+<body style="container">
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html
+++ b/test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script></head>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script><script type="text/javascript" src="fake.js"></script></head>
 <body style="container">
 <p>Fake body</p>
 </body>

--- a/test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html
+++ b/test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><script type="text/javascript" src="fake.js"></script></head>
+<body style="container">
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-<link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo" rel="alternate">
+<head><meta charset="utf-8">
+<link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="stylesheet" src="base.css"><link hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo" rel="alternate">
 <link rel="stylesheet" src="fake.css">
 </head>
 <body>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo" rel="alternate">
+<link rel="stylesheet" src="fake.css">
+</head>
+<body>
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
-
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><meta charset="utf-8">
+<link rel="stylesheet" src="base.css">
 <link rel="stylesheet" src="fake.css">
 </head>
 <body>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+
+<link rel="stylesheet" src="fake.css">
+</head>
+<body>
+<p>Fake body</p>
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><meta charset="utf-8">
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script><meta charset="utf-8">
 <link rel="stylesheet" src="base.css">
 <link rel="stylesheet" src="fake.css">
 </head>

--- a/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
+++ b/test/fixtures/basic_html/insert_with_exist_hreflang_expected.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/zh-CHT/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/zh-CHS/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 
 <link rel="stylesheet" src="fake.css">
 </head>

--- a/test/fixtures/real_html/stack_overflow_hreflang.html
+++ b/test/fixtures/real_html/stack_overflow_hreflang.html
@@ -251,7 +251,7 @@
   StackExchange.ready(function() { StackExchange.topbar.init(); });
   StackExchange.scrollPadding.setPaddingTop(60, 10);     </script>
 
-<div class="container _full ">
+<div class="container _full">
 
 
 

--- a/test/fixtures/real_html/stack_overflow_hreflang_expected.html
+++ b/test/fixtures/real_html/stack_overflow_hreflang_expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 
   <title>Stack Overflow - Where Developers Learn, Share, &amp; Build Careers</title>
   <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/stackoverflow/img/favicon.ico?v=4f32ecc8f43d">

--- a/test/fixtures/real_html/stack_overflow_hreflang_expected.html
+++ b/test/fixtures/real_html/stack_overflow_hreflang_expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 
   <title>Stack Overflow - Where Developers Learn, Share, &amp; Build Careers</title>
   <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/stackoverflow/img/favicon.ico?v=4f32ecc8f43d">

--- a/test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html
+++ b/test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo&amp;param=yeah"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo&amp;param=yeah"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo&amp;param=yeah"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo&amp;param=yeah"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=ja&amp;defaultLang=ja&amp;urlPattern=path&amp;langCodeAliases=[]&amp;version=WOVN.php" data-wovnio-type="backend_without_api" async></script>
 
   <title>Stack Overflow - Where Developers Learn, Share, &amp; Build Careers</title>
   <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/stackoverflow/img/favicon.ico?v=4f32ecc8f43d">

--- a/test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html
+++ b/test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 
-<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo&amp;param=yeah"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo&amp;param=yeah"><script src='//j.wovn.io/1' data-wovnio='key=toK3n' data-wovnio-type='backend_without_api' async></script>
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo&amp;param=yeah"><link rel="alternate" hreflang="vi" href="http://ja.localhost/vi/t.php?hey=yo&amp;param=yeah"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=ja&defaultLang=ja&urlPattern=path&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>
 
   <title>Stack Overflow - Where Developers Learn, Share, &amp; Build Careers</title>
   <link rel="shortcut icon" href="https://cdn.sstatic.net/Sites/stackoverflow/img/favicon.ico?v=4f32ecc8f43d">

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -445,6 +445,27 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
+  public function testInsertSnippetForHtmlWithSnippetCode()
+  {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_snippet_when_already_exist.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['default_lang'] = 'ja';
+    $store->settings['supported_langs'] = array('en', 'vi');
+    $store->settings['disable_api_request_for_default_lang'] = true;
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
   public function testInsertHreflangIntoHtmlTag()
   {
     libxml_use_internal_errors(true);

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -129,7 +129,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=vi\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
+    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=vi\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -142,7 +142,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
+    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -155,7 +155,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
+    $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -169,7 +169,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>hello<a>world</a></html>";
+    $expected_html = "<html><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script>hello<a>world</a></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -183,7 +183,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $converter = new HtmlConverter($html, null, $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
+    $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script>こんにちは</html>";
     $expected_html = mb_convert_encoding($expected_html, 'SJIS');
 
     $this->assertEquals($expected_html, $translated_html);
@@ -200,7 +200,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
       $converter = new HtmlConverter($html, $encoding, $token, $store, $headers);
       list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-      $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
+      $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php\" data-wovnio-type=\"backend_without_api\" async></script>こんにちは</html>";
       $expected_html = mb_convert_encoding($expected_html, $encoding);
       $this->assertEquals($expected_html, $translated_html);
     }

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -313,6 +313,69 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
+  /**
+   * @group test
+   */
+  public function testInsertHreflangIntoHeadWithStyle() {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_head_style.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['default_lang'] = 'ja';
+    $store->settings['supported_langs'] = array('en', 'vi');
+    $store->settings['disable_api_request_for_default_lang'] = true;
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_head_style_expected.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
+  public function testInsertHreflangIntoBodyTag() {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_body.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['default_lang'] = 'ja';
+    $store->settings['supported_langs'] = array('en', 'vi');
+    $store->settings['disable_api_request_for_default_lang'] = true;
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_body_expected.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
+  public function testInsertHreflangIntoHtmlTag() {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_html.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['default_lang'] = 'ja';
+    $store->settings['supported_langs'] = array('en', 'vi');
+    $store->settings['disable_api_request_for_default_lang'] = true;
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_html_expected.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
   public function testInsertHreflangShouldRemoveExistHreflangTags() {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_with_exist_hreflang.html');
@@ -352,6 +415,9 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
+  /**
+   * @group test
+   */
   public function testInsertHreflangWithCustomLangAliasAndChinese() {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_hreflang.html');

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -123,10 +123,26 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
-    $converter = new HtmlConverter($html, 'UTF-8', $token);
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['supported_langs'] = array('en', 'vi');
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><body><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
+    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=vi\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
+    $this->assertEquals($expected_html, $translated_html);
+  }
+
+  public function testConvertToAppropriateForApiBodyWithEmptySupportedLangs()
+  {
+    $html = '<html><body><a>hello</a></body></html>';
+    $token = 'toK3n';
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -134,10 +150,12 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
     $token = 'toK3n';
-    $converter = new HtmlConverter($html, 'UTF-8', $token);
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><head><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
+    $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -145,10 +163,13 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html>hello<a>world</a></html>';
     $token = 'toK3n';
-    $converter = new HtmlConverter($html, 'UTF-8', $token);
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['supported_langs'] = array();
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>hello<a>world</a></html>";
+    $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>hello<a>world</a></html>";
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -157,10 +178,12 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = mb_convert_encoding('<html>こんにちは</html>', 'SJIS');
 
     $token = 'toK3n';
-    $converter = new HtmlConverter($html, null, $token);
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, null, $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-    $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
+    $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
     $expected_html = mb_convert_encoding($expected_html, 'SJIS');
 
     $this->assertEquals($expected_html, $translated_html);
@@ -172,10 +195,12 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
       $html = mb_convert_encoding('<html>こんにちは</html>', $encoding);
 
       $token = 'toK3n';
-      $converter = new HtmlConverter($html, $encoding, $token);
+      $env = $this->getEnv();
+      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      $converter = new HtmlConverter($html, $encoding, $token, $store, $headers);
       list($translated_html) = $converter->insertSnippetAndHreflangTags();
 
-      $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
+      $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://ja.localhost/t.php?hey=yo&amp;wovn=en\"><script src='//j.wovn.io/1' data-wovnio='key=toK3n&backend=true&currentLang=en&defaultLang=en&urlPattern=query&langCodeAliases=[]&version=WOVN.php' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
       $expected_html = mb_convert_encoding($expected_html, $encoding);
       $this->assertEquals($expected_html, $translated_html);
     }
@@ -194,7 +219,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithMultipleWovnIgnore()
   {
     $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
     $keys = $marker->keys();
 
@@ -205,7 +232,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithForm()
   {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
     $keys = $marker->keys();
 
@@ -216,7 +245,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithMultipleForm()
   {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
     $keys = $marker->keys();
 
@@ -227,7 +258,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithFormAndWovnIgnore()
   {
     $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
     $keys = $marker->keys();
 
@@ -238,7 +271,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithHiddenInput()
   {
     $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
     $keys = $marker->keys();
 
@@ -249,7 +284,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithHiddenInputMultipleTimes()
   {
     $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
     $keys = $marker->keys();
 
@@ -260,7 +297,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithScript()
   {
     $html = '<html><body><script>console.log("hello")</script>world</body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
     $keys = $marker->keys();
 
@@ -271,7 +310,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithMultipleScript()
   {
     $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
     $keys = $marker->keys();
 
@@ -282,7 +323,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   public function testConvertToAppropriateForApiBodyWithComment()
   {
     $html = '<html><body>hello<!-- backend-wovn-ignore    -->ignored <!--/backend-wovn-ignore-->  world</body></html>';
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
     $keys = $marker->keys();
 
@@ -301,7 +344,9 @@ ignored2
 <!--/backend-wovn-ignore-->
 bye
 </body></html>";
-    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
     $keys = $marker->keys();
 
@@ -336,9 +381,28 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  /**
-   * @group test
-   */
+  public function testInsertHreflangWithCustomLangCodes()
+  {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    $store->settings['default_lang'] = 'en';
+    $store->settings['supported_langs'] = array('en', 'vi', 'zh-CHS');
+    $store->settings['disable_api_request_for_default_lang'] = true;
+    $store->settings['url_pattern_name'] = 'path';
+    $store->settings['custom_lang_aliases'] = array('zh-CHS' => 'custom_simple');
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags();
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
   public function testInsertHreflangIntoHeadWithStyle()
   {
     libxml_use_internal_errors(true);

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -22,6 +22,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testConvertAndRevertAtStackOverflow() {
+    $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
+
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/stack_overflow.html');
     $token = 'toK3n';
@@ -43,6 +45,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testConvertAndRevertAtYoutube() {
+    $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
+
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/youtube.html');
     $token = 'toK3n';
@@ -64,6 +68,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testConvertAndRevertAtYelp() {
+    $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
+
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/yelp.html');
     $token = 'toK3n';
@@ -85,6 +91,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testConvertAndRevertAtYahooJp() {
+    $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
+
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/yahoo_jp.html');
     $token = 'toK3n';
@@ -109,10 +117,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
-    $keys = $marker->keys();
-
-    $this->assertEquals(0, count($keys));
+    list($translated_html) = $converter->convertToAppropriateForApiBody();
 
     $expected_html = "<html><body><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
@@ -122,10 +127,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
-    $keys = $marker->keys();
-
-    $this->assertEquals(0, count($keys));
+    list($translated_html) = $converter->convertToAppropriateForApiBody();
 
     $expected_html = "<html><head><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
     $this->assertEquals($expected_html, $translated_html);
@@ -135,10 +137,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $html = '<html>hello<a>world</a></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
-    $keys = $marker->keys();
-
-    $this->assertEquals(0, count($keys));
+    list($translated_html) = $converter->convertToAppropriateForApiBody();
 
     $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>hello<a>world</a></html>";
     $this->assertEquals($expected_html, $translated_html);
@@ -149,13 +148,11 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
 
     $token = 'toK3n';
     $converter = new HtmlConverter($html, null, $token);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
-    $keys = $marker->keys();
-
-    $this->assertEquals(0, count($keys));
+    list($translated_html) = $converter->convertToAppropriateForApiBody();
 
     $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
     $expected_html = mb_convert_encoding($expected_html, 'SJIS');
+
     $this->assertEquals($expected_html, $translated_html);
   }
 
@@ -165,10 +162,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
 
       $token = 'toK3n';
       $converter = new HtmlConverter($html, $encoding, $token);
-      list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
-      $keys = $marker->keys();
-
-      $this->assertEquals(0, count($keys));
+      list($translated_html) = $converter->convertToAppropriateForApiBody();
 
       $expected_html = "<html><script src='//j.wovn.io/1' data-wovnio='key=$token' data-wovnio-type='backend_without_api' async></script>こんにちは</html>";
       $expected_html = mb_convert_encoding($expected_html, $encoding);
@@ -177,13 +171,12 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testConvertToAppropriateForApiBodyWithWovnIgnore() {
+    $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
     $html = '<html><body><a wovn-ignore>hello</a></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
-    list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
-    $keys = $marker->keys();
+    list($translated_html) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
 
-    $this->assertEquals(1, count($keys));
-    $this->assertEquals("<html><body><a wovn-ignore>$keys[0]</a></body></html>", $translated_html);
+    $this->assertEquals("<html><body><a wovn-ignore></a></body></html>", $translated_html);
   }
 
   public function testConvertToAppropriateForApiBodyWithMultipleWovnIgnore() {
@@ -313,7 +306,7 @@ bye
     $store->settings['url_pattern_name'] = 'path';
 
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody(false);
+    list($translated_html) = $converter->convertToAppropriateForApiBody(false);
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang_expected.html');
 
@@ -353,7 +346,7 @@ bye
     $store->settings['url_pattern_name'] = 'path';
 
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
-    list($translated_html, $marker) = $converter->convertToAppropriateForApiBody();
+    list($translated_html) = $converter->convertToAppropriateForApiBody();
 
     $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected.html');
 

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -13,15 +13,18 @@ use Wovnio\Wovnphp\Utils;
 use Wovnio\Html\HtmlReplaceMarker;
 use Wovnio\ModifiedVendor\simple_html_dom;
 
-class HtmlConverterTest extends PHPUnit_Framework_TestCase {
-  private function getEnv($num="") {
+class HtmlConverterTest extends PHPUnit_Framework_TestCase
+{
+  private function getEnv($num = "")
+  {
     $env = array();
     $file = parse_ini_file(dirname(__FILE__) . '/../mock_env' . $num . '.ini');
     $env = $file['env'];
     return $env;
   }
 
-  public function testConvertAndRevertAtStackOverflow() {
+  public function testConvertAndRevertAtStackOverflow()
+  {
     $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
 
     libxml_use_internal_errors(true);
@@ -32,19 +35,20 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags();
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_expected.html');
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
     $expected_html = $doc->saveHTML();
 
     $actual_html_text = $marker->revert($translated_html);
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
     $actual_html = $doc->saveHTML();
 
     $this->assertEquals($expected_html, $actual_html);
   }
 
-  public function testConvertAndRevertAtYoutube() {
+  public function testConvertAndRevertAtYoutube()
+  {
     $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
 
     libxml_use_internal_errors(true);
@@ -55,19 +59,20 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags();
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/youtube_expected.html');
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
     $expected_html = $doc->saveHTML();
 
     $actual_html_text = $marker->revert($translated_html);
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
     $actual_html = $doc->saveHTML();
 
     $this->assertEquals($expected_html, $actual_html);
   }
 
-  public function testConvertAndRevertAtYelp() {
+  public function testConvertAndRevertAtYelp()
+  {
     $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
 
     libxml_use_internal_errors(true);
@@ -78,19 +83,20 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags();
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/yelp_expected.html');
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
     $expected_html = $doc->saveHTML();
 
     $actual_html_text = $marker->revert($translated_html);
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
     $actual_html = $doc->saveHTML();
 
     $this->assertEquals($expected_html, $actual_html);
   }
 
-  public function testConvertAndRevertAtYahooJp() {
+  public function testConvertAndRevertAtYahooJp()
+  {
     $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
 
     libxml_use_internal_errors(true);
@@ -101,19 +107,20 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags();
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/yahoo_jp_expected.html');
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
     $expected_html = $doc->saveHTML();
 
     $actual_html_text = $marker->revert($translated_html);
-    $doc = new DOMDocument( "1.0", "ISO-8859-15" );
+    $doc = new DOMDocument("1.0", "ISO-8859-15");
     $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
     $actual_html = $doc->saveHTML();
 
     $this->assertEquals($expected_html, $actual_html);
   }
 
-  public function testConvertToAppropriateForApiBody() {
+  public function testConvertToAppropriateForApiBody()
+  {
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
@@ -123,7 +130,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expected_html, $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithHead() {
+  public function testConvertToAppropriateForApiBodyWithHead()
+  {
     $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
@@ -133,7 +141,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expected_html, $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithoutBody() {
+  public function testConvertToAppropriateForApiBodyWithoutBody()
+  {
     $html = '<html>hello<a>world</a></html>';
     $token = 'toK3n';
     $converter = new HtmlConverter($html, 'UTF-8', $token);
@@ -143,7 +152,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expected_html, $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithoutEncoding() {
+  public function testConvertToAppropriateForApiBodyWithoutEncoding()
+  {
     $html = mb_convert_encoding('<html>こんにちは</html>', 'SJIS');
 
     $token = 'toK3n';
@@ -156,8 +166,9 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals($expected_html, $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithSupportedEncoding() {
-    foreach(HtmlConverter::$supported_encodings as $encoding) {
+  public function testConvertToAppropriateForApiBodyWithSupportedEncoding()
+  {
+    foreach (HtmlConverter::$supported_encodings as $encoding) {
       $html = mb_convert_encoding('<html>こんにちは</html>', $encoding);
 
       $token = 'toK3n';
@@ -170,7 +181,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     }
   }
 
-  public function testConvertToAppropriateForApiBodyWithWovnIgnore() {
+  public function testConvertToAppropriateForApiBodyWithWovnIgnore()
+  {
     $this->markTestSkipped("Skip this test because we don't support wovn-ignore for now");
     $html = '<html><body><a wovn-ignore>hello</a></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
@@ -179,7 +191,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><a wovn-ignore></a></body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithMultipleWovnIgnore() {
+  public function testConvertToAppropriateForApiBodyWithMultipleWovnIgnore()
+  {
     $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
@@ -189,7 +202,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><a wovn-ignore>$keys[0]</a>ignore<div wovn-ignore>$keys[1]</div></body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithForm() {
+  public function testConvertToAppropriateForApiBodyWithForm()
+  {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
@@ -199,7 +213,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><form>$keys[0]</form>world</body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithMultipleForm() {
+  public function testConvertToAppropriateForApiBodyWithMultipleForm()
+  {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
@@ -209,7 +224,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><form>$keys[0]</form>world<form>$keys[1]</form></body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithFormAndWovnIgnore() {
+  public function testConvertToAppropriateForApiBodyWithFormAndWovnIgnore()
+  {
     $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
@@ -219,7 +235,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><form wovn-ignore>$keys[0]</form>world</body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithHiddenInput() {
+  public function testConvertToAppropriateForApiBodyWithHiddenInput()
+  {
     $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
@@ -229,7 +246,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><input type=\"hidden\" value=\"$keys[0]\">world</body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithHiddenInputMultipleTimes() {
+  public function testConvertToAppropriateForApiBodyWithHiddenInputMultipleTimes()
+  {
     $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
@@ -239,7 +257,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><input type=\"hidden\" value=\"$keys[0]\">world<input type=\"hidden\" value=\"$keys[1]\"></body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithScript() {
+  public function testConvertToAppropriateForApiBodyWithScript()
+  {
     $html = '<html><body><script>console.log("hello")</script>world</body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
@@ -249,7 +268,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body><script>$keys[0]</script>world</body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithMultipleScript() {
+  public function testConvertToAppropriateForApiBodyWithMultipleScript()
+  {
     $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
@@ -259,7 +279,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><head><script>$keys[0]</script></head><body>world<script>$keys[1]</script></body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithComment() {
+  public function testConvertToAppropriateForApiBodyWithComment()
+  {
     $html = '<html><body>hello<!-- backend-wovn-ignore    -->ignored <!--/backend-wovn-ignore-->  world</body></html>';
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n');
     list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
@@ -269,7 +290,8 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals("<html><body>hello<!-- backend-wovn-ignore    -->$keys[0]<!--/backend-wovn-ignore-->  world</body></html>", $translated_html);
   }
 
-  public function testConvertToAppropriateForApiBodyWithMultipleComment() {
+  public function testConvertToAppropriateForApiBodyWithMultipleComment()
+  {
     $html = "<html><body>hello<!-- backend-wovn-ignore    -->ignored <!--/backend-wovn-ignore-->  world
 line break
 <!-- backend-wovn-ignore    -->
@@ -293,7 +315,8 @@ bye
     $this->assertEquals($expected_html, $translated_html);
   }
 
-  public function testInsertHreflang() {
+  public function testInsertHreflang()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang.html');
     $token = 'toK3n';
@@ -316,7 +339,8 @@ bye
   /**
    * @group test
    */
-  public function testInsertHreflangIntoHeadWithStyle() {
+  public function testInsertHreflangIntoHeadWithStyle()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_head_style.html');
     $token = 'toK3n';
@@ -336,7 +360,8 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  public function testInsertHreflangIntoBodyTag() {
+  public function testInsertHreflangIntoBodyTag()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_body.html');
     $token = 'toK3n';
@@ -356,7 +381,8 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  public function testInsertHreflangIntoHtmlTag() {
+  public function testInsertHreflangIntoHtmlTag()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_html.html');
     $token = 'toK3n';
@@ -376,7 +402,8 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  public function testInsertHreflangShouldRemoveExistHreflangTags() {
+  public function testInsertHreflangShouldRemoveExistHreflangTags()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_with_exist_hreflang.html');
     $token = 'toK3n';
@@ -395,7 +422,8 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  public function testInsertHreflangHtmlEntities() {
+  public function testInsertHreflangHtmlEntities()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang.html');
     $token = 'toK3n';
@@ -408,17 +436,15 @@ bye
     $store->settings['url_pattern_name'] = 'path';
 
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
-    list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
 
     $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html');
 
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  /**
-   * @group test
-   */
-  public function testInsertHreflangWithCustomLangAliasAndChinese() {
+  public function testInsertHreflangWithCustomLangAliasAndChinese()
+  {
     libxml_use_internal_errors(true);
     $html = file_get_contents('test/fixtures/basic_html/insert_hreflang.html');
     $token = 'toK3n';
@@ -438,7 +464,8 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
-  private function executeConvert($converter, $html, $charset, $name) {
+  private function executeConvert($converter, $html, $charset, $name)
+  {
     $dom = simple_html_dom::str_get_html($html, $charset, false, false, $charset, false);
     $marker = new HtmlReplaceMarker();
 
@@ -453,7 +480,8 @@ bye
     return array($converted_html, $marker);
   }
 
-  private function executeRemoveBackendWovnIgnoreComment($converter, $html) {
+  private function executeRemoveBackendWovnIgnoreComment($converter, $html)
+  {
     $marker = new HtmlReplaceMarker();
 
     $method = new ReflectionMethod($converter, 'removeBackendWovnIgnoreComment');


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

- Stop using simple_html_dom because of memory leak issue
- Do not send request to API if current lang is default lang
- Inject snippet/hreflangs using regex (doing)

### Comments


### Release comments (new feature)
