### PR TITLE
Stop depending on real `wovn.ini` at test

### DIFF
--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -13,22 +13,30 @@
     private $values = null;
 
     /**
-     *  Constructor of the Store class
-     *  
-     *  @param string $settingsFile A settings file name 
-     *  @return void
+     * @param string $settingFileName
+     * @return Store
      */
-    public function __construct($settingsFile='') {
-      if ($settingsFile==='') {
-        $settingsFile = DIRNAME(__FILE__) . '/../../../../wovn.ini';
-      }
-      $defaultSettings = $this->defaultSettings();
-      if (file_exists($settingsFile)) {
-        $userSettings = $this->updateSettings(parse_ini_file($settingsFile, true));
+    public static function createFromFile($settingFileName) {
+      if (file_exists($settingFileName)) {
+        $userSettings = parse_ini_file($settingFileName, true);
       }
       else {
-        $userSettings = array();
+        $userSettings = null;
       }
+
+      return new Store($userSettings);
+    }
+
+    /**
+     *  Constructor of the Store class
+     *  
+     *  @param array $userSettings
+     *  @return void
+     */
+    public function __construct($userSettings) {
+      $defaultSettings = $this->defaultSettings();
+      $userSettings = $this->updateSettings($userSettings);
+
       $this->settings = array_merge($defaultSettings, $userSettings);
 
       // Use default api_url property when user api_url property is empty.
@@ -79,6 +87,10 @@
      * @return array The new settings of the user
      */
     public function updateSettings($vals=array()) {
+      if (isset($vals['default_lang']) === false) {
+        return array();
+      }
+
       // GETTING THE LANGUAGE AND SETTING IT AS CODE
       $vals['default_lang'] = Lang::getCode($vals['default_lang']);
 

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -5,7 +5,8 @@ class Utils {
 
   // will return the store and headers objects
   public static function getStoreAndHeaders(&$env) {
-    $store = new Store;
+    $file = DIRNAME(__FILE__) . '/../../../../wovn.ini';
+    $store = Store::createFromFile($file);
     $headers = new Headers($env, $store);
     return array($store, $headers);
   }

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -14,9 +14,12 @@
 
   require_once 'src/wovnio/modified_vendor/simple_html_dom.php';
 
+  require_once 'test/helpers/StoreAndHeaderHelper.php';
+
   use Wovnio\Wovnphp\API;
   use Wovnio\Wovnphp\Utils;
   use Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
+  use Wovnio\Test\Helpers\StoreAndHeaderHelper;
 
   class APITest extends PHPUnit_Framework_TestCase {
     private function getEnv($num = "") {
@@ -64,7 +67,7 @@
 
     public function testTranslationURL() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $body = '<html></html>';
       $expected_api_url = $this->getExpectedUrl($store, $headers, $body);
 
@@ -73,7 +76,7 @@
 
     public function testTranslate() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $html = '<html><head></head><body><h1>en</h1></body></html>';
       $response = '{"body":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
@@ -106,7 +109,7 @@
 
     public function testTranslateWithCustomLangAliases() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $store->settings['custom_lang_aliases'] = array('ja' => 'ja-test');
       $token = $store->settings['project_token'];
 
@@ -143,7 +146,7 @@
 
     public function testTranslateWithWovnIgnore() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $html = '<html><head></head><body><h1 wovn-ignore>en</h1>hello</body></html>';
       $response = '{"body":"\u003chtml\u003e\u003chead\u003e\u003c\u002fhead\u003e\u003cbody\u003e\u003ch1 wovn-ignore\u003e\u003c\u0021\u002d\u002d\u0020__wovn\u002dbackend\u002dignored\u002dkey\u002d0\u0020\u002d\u002d\u003e\u003c\u002fh1\u003eBonjour\u003c\u002fbody\u003e\u003c\u002fhtml\u003e"}';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
@@ -176,7 +179,7 @@
 
     public function testTranslateWithErrorHandled() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $html = '<html><head></head><body><h1>en</h1></body></html>';
       $response = '{"missingBodyError":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
@@ -209,7 +212,7 @@
 
     public function testTranslateWithConnectionErrorHandled() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $html = '<html><head></head><body><h1>en</h1></body></html>';
       $expected_url = $this->getExpectedUrl($store, $headers, $html);
 
@@ -241,7 +244,7 @@
 
     public function testTranslateWithoutMakingAPICallBySetting() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $store->settings['disable_api_request_for_default_lang'] = true;
       $store->settings['default_lang'] = 'en';
 
@@ -258,7 +261,7 @@
 
     public function testTranslateWhenDefaultLangAndSettingIsOff() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $store->settings['disable_api_request_for_default_lang'] = false;
       $store->settings['default_lang'] = 'en';
       $store->settings['url_pattern_name'] = 'path';
@@ -298,7 +301,7 @@
 
     public function testTranslateWithSaveMemoryBySendingWovnIgnoreContent() {
       $env = $this->getEnv('_path');
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $store->settings['save_memory_by_sending_wovn_ignore_content'] = true;
 
       $html = '<html><head></head><body><h1 wovn-ignore>ignore content</h1></body></html>';

--- a/test/HeadersTest.php
+++ b/test/HeadersTest.php
@@ -24,12 +24,12 @@ class HeadersTest extends PHPUnit_Framework_TestCase {
   }
 
   function createStore($pattern='path') {
-    $store = new Store('./test/config.ini');
-    $store->settings['default_lang'] = 'en';
-    $store->settings['supported_langs'] = array('en');
-    $store->settings['url_pattern_name'] = $pattern;
-    $store->settings['project_token'] = 'KK9kZ';
-    $store->settings = $store->updateSettings($store->settings);
+    $store = new Store(array(
+      'default_lang' => 'en',
+      'supported_langs' => array('en'),
+      'url_pattern_name' => $pattern,
+      'project_token' => 'KK9kZ'
+    ));
     return $store;
   }
 

--- a/test/StoreTest.php
+++ b/test/StoreTest.php
@@ -44,7 +44,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'backend_port = "6379"' . "\n" . 
             'default_lang = "English"' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals(array('a='), $store->settings['query']);
   }
@@ -61,7 +61,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'backend_port = "6379"' . "\n" . 
             'default_lang = "English"' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals(array('a=', 'b='), $store->settings['query']);
   }
@@ -78,7 +78,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'backend_port = "6379"' . "\n" . 
             'default_lang = "English"' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals(array('a=', 'b='), $store->settings['query']);
   }
@@ -92,7 +92,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
       'default_lang = "English"' . "\n" .
       'encoding = UTF-8' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('UTF-8', $store->settings['encoding']);
   }
@@ -106,7 +106,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
       'default_lang = "English"' . "\n" .
       'encoding = INVALID_ENCODING' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals(null, $store->settings['encoding']);
   }
@@ -119,7 +119,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
     $data = 'project_token = "T0k3N"' . "\n" .
       'default_lang = "English"' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals(null, $store->settings['encoding']);
   }
@@ -133,7 +133,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'default_lang = "English"' . "\n" .
             'use_proxy = 1' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('https://wovn.global.ssl.fastly.net/v0/', $store->settings['api_url']);
     $this->assertArrayHasKey('use_proxy', $store->settings);
@@ -149,7 +149,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'default_lang = "English"' . "\n" .
             'wovn_dev_mode = 1' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertArrayHasKey('wovn_dev_mode', $store->settings);
     $this->assertEquals(1, $store->settings['wovn_dev_mode']);
@@ -164,7 +164,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'default_lang = "English"' . "\n" .
             'wovn_dev_mode = 0' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertArrayHasKey('wovn_dev_mode', $store->settings);
     $this->assertEquals(0, $store->settings['wovn_dev_mode']);
@@ -178,7 +178,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
     $data = 'project_token = "T0k3N"' . "\n" .
             'default_lang = "English"' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertArrayHasKey('wovn_dev_mode', $store->settings);
     $this->assertEquals(0, $store->settings['wovn_dev_mode']);
@@ -193,7 +193,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'default_lang = "English"' . "\n" .
             'wovn_dev_mode = 1' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('http://api.dev-wovn.io:3000/v0/', $store->settings['api_url']);
   }
@@ -207,7 +207,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'default_lang = "English"' . "\n" .
             'wovn_dev_mode = 0' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('https://wovn.global.ssl.fastly.net/v0/', $store->settings['api_url']);
   }
@@ -222,7 +222,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'api_url = "https://test-api.io"' . "\n" .
             'wovn_dev_mode = 1' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('https://test-api.io', $store->settings['api_url']);
   }
@@ -237,7 +237,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'api_url = "https://test-api.io"' . "\n" .
             'wovn_dev_mode = 0' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('https://test-api.io', $store->settings['api_url']);
   }
@@ -252,7 +252,7 @@ class StoreTest extends PHPUnit_Framework_TestCase {
             'custom_lang_aliases["ja"] = "ja-test"' . "\n" .
             'wovn_dev_mode = 0' . "\n";
     file_put_contents($file_config, $data);
-    $store = new Store($file_config);
+    $store = Store::createFromFile($file_config);
     unlink($file_config);
     $this->assertEquals('ja-test', $store->convertToCustomLangCode('ja'));
   }

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -19,18 +19,21 @@ class UrlTest extends PHPUnit_Framework_TestCase {
   }
 
   private function getStarted ($pattern='path', $additional_env=array()) {
-    $store = new Store();
-    $store->settings['default_lang'] = 'ja';
-    $store->settings['supported_langs'] = array('en');
+    $url_pattern_reg = null;
     if ($pattern === 'query') {
-      $store->settings['url_pattern_reg'] = "((\?.*&)|\?)wovn=(?P<lang>[^&]+)(&|$)";
+      $url_pattern_reg = "((\?.*&)|\?)wovn=(?P<lang>[^&]+)(&|$)";
     }
     if ($pattern === 'subdomain') {
-      $store->settings['url_pattern_reg'] = "^(?P<lang>[^.]+)\.";
+      $url_pattern_reg = "^(?P<lang>[^.]+)\.";
     }
-    $store->settings['url_pattern_name'] = $pattern;
 
-    $store->settings['project_token'] = 'KK9kZ';
+    $store = new Store(array (
+      'default_lang' => 'ja',
+      'supported_langs' => array('en'),
+      'url_pattern_reg' => $url_pattern_reg,
+      'url_pattern_name' => $pattern,
+      'project_token' => 'KK9kZ',
+    ));
     $env = array_merge($this->getEnv('_' . $pattern), $additional_env);
     $headers = new Headers($env, $store);
     return array($store, $env, $headers);

--- a/test/helpers/StoreAndHeaderHelper.php
+++ b/test/helpers/StoreAndHeaderHelper.php
@@ -1,0 +1,13 @@
+<?php
+namespace Wovnio\Test\Helpers;
+
+use Wovnio\Wovnphp\Store;
+use Wovnio\Wovnphp\Headers;
+
+class StoreAndHeaderHelper {
+  public static function create($env) {
+    $store = new Store(array());
+    $headers = new Headers($env, $store);
+    return array($store, $headers);
+  }
+}

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -10,10 +10,13 @@ require_once 'src/wovnio/modified_vendor/simple_html_dom.php';
 require_once 'src/wovnio/wovnphp/Url.php';
 require_once 'src/wovnio/wovnphp/Lang.php';
 
+require_once 'test/helpers/StoreAndHeaderHelper.php';
+
 use Wovnio\Html\HtmlConverter;
 use Wovnio\Wovnphp\Utils;
 use Wovnio\Html\HtmlReplaceMarker;
 use Wovnio\ModifiedVendor\simple_html_dom;
+use Wovnio\Test\Helpers\StoreAndHeaderHelper;
 
 class HtmlConverterTest extends PHPUnit_Framework_TestCase
 {
@@ -32,7 +35,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
 
@@ -56,7 +59,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
 
@@ -80,7 +83,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
 
@@ -104,7 +107,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
 
@@ -126,7 +129,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['supported_langs'] = array('en', 'vi');
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
@@ -140,7 +143,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['supported_langs'] = array('en', 'vi');
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->insertSnippetAndHreflangTags(true);
@@ -154,7 +157,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['supported_langs'] = array('en', 'vi');
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
@@ -168,7 +171,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -181,7 +184,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -194,7 +197,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html>hello<a>world</a></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['supported_langs'] = array();
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
@@ -208,7 +211,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -221,7 +224,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -234,7 +237,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html>hello<a>world</a></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['supported_langs'] = array();
     $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
@@ -249,7 +252,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
 
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, null, $token, $store, $headers);
     list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -266,7 +269,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
 
       $token = 'toK3n';
       $env = $this->getEnv();
-      list($store, $headers) = Utils::getStoreAndHeaders($env);
+      list($store, $headers) = StoreAndHeaderHelper::create($env);
       $converter = new HtmlConverter($html, $encoding, $token, $store, $headers);
       list($translated_html) = $converter->convertToAppropriateBodyForApi();
 
@@ -281,7 +284,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
     $html = '<html><body><a wovn-ignore>hello</a></body></html>';
     $token = 'toK3n';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, null, $token, $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
     $keys = $marker->keys();
@@ -294,7 +297,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
     $keys = $marker->keys();
@@ -307,7 +310,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
     $keys = $marker->keys();
@@ -320,7 +323,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
     $keys = $marker->keys();
@@ -333,7 +336,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
     $keys = $marker->keys();
@@ -346,7 +349,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
     $keys = $marker->keys();
@@ -359,7 +362,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
     $keys = $marker->keys();
@@ -372,7 +375,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body><script>console.log("hello")</script>world</body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
     $keys = $marker->keys();
@@ -385,7 +388,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
     $keys = $marker->keys();
@@ -398,7 +401,7 @@ class HtmlConverterTest extends PHPUnit_Framework_TestCase
   {
     $html = '<html><body>hello<!-- backend-wovn-ignore    -->ignored <!--/backend-wovn-ignore-->  world</body></html>';
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
     $keys = $marker->keys();
@@ -419,7 +422,7 @@ ignored2
 bye
 </body></html>";
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $converter = new HtmlConverter($html, 'UTF-8', 'toK3n', $store, $headers);
     list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
     $keys = $marker->keys();
@@ -441,7 +444,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -462,7 +465,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'en';
     $store->settings['supported_langs'] = array('en', 'vi', 'zh-CHS');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -484,7 +487,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -505,7 +508,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -526,7 +529,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -547,7 +550,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -568,7 +571,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi', 'zh-CHT', 'zh-CHS');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -588,7 +591,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv('html_entities');
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi');
     $store->settings['disable_api_request_for_default_lang'] = true;
@@ -609,7 +612,7 @@ bye
     $token = 'toK3n';
 
     $env = $this->getEnv();
-    list($store, $headers) = Utils::getStoreAndHeaders($env);
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
     $store->settings['default_lang'] = 'ja';
     $store->settings['supported_langs'] = array('en', 'vi', 'zh-CHT', 'zh-CHS');
     $store->settings['custom_lang_aliases'] = array('en' => 'custom_en', 'zh-CHS' => 'custom_simple');


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
Stop depending on real `wovn.ini` at test

### Comments
Currently, tests assume there is default configuration or there is no file.
But there is in reality.

To divide dependency,

1. Change Store's constructor to get parsed configuration as array
2. Make simple Builder to load and parse configuration.
3. Fix tests
