### PR TITLE
Add setting for checking and ignoring AMP files

### DIFF
--- a/hack/run_integration_test.sh
+++ b/hack/run_integration_test.sh
@@ -20,6 +20,8 @@ docker run -d -p 80:80 -v $(pwd):/var/www/html/WOVN.php -v $(pwd)/integration_te
 waitServerUp
 
 curl "localhost/index.php?wovn=ja" -o /tmp/result.txt
-
 # diff returns non 0 if there are differences or troubles.
 diff /tmp/result.txt integration_test/index_expected.html
+
+curl "localhost/amp.php" -o /tmp/result.txt
+diff /tmp/result.txt integration_test/amp_expected.html

--- a/integration_test/amp.php
+++ b/integration_test/amp.php
@@ -1,0 +1,10 @@
+<?php
+require_once('WOVN.php/src/wovn_interceptor.php');
+?>
+<html ⚡>
+<head>
+</head>
+<body>
+test
+</body>
+</html>

--- a/integration_test/amp_expected.html
+++ b/integration_test/amp_expected.html
@@ -1,0 +1,7 @@
+<html ⚡>
+<head>
+</head>
+<body>
+test
+</body>
+</html>

--- a/integration_test/wovn.ini
+++ b/integration_test/wovn.ini
@@ -8,3 +8,4 @@ supported_langs[] = "fr"
 supported_langs[] = "bg"
 supported_langs[] = "en"
 api_url = "http://localhost/v0/"
+check_amp=1

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -33,12 +33,14 @@
     ob_start(function($buffer) use ($headers, $store) {
       $headers->responseOut();
 
-      if(!empty($buffer) && $buffer != strip_tags($buffer)) {
-        $translated_buffer = API::translate($store, $headers, $buffer);
+      if(!empty($buffer) && Utils::isHtml($buffer)) {
+        if (!$store->settings['check_amp'] || !Utils::isAmp($buffer)) {
+          $translated_buffer = API::translate($store, $headers, $buffer);
 
-        if ($translated_buffer !== NULL && !empty($translated_buffer)) {
-          Utils::changeHeaders($translated_buffer, $store);
-          return $translated_buffer;
+          if ($translated_buffer !== NULL && !empty($translated_buffer)) {
+            Utils::changeHeaders($translated_buffer, $store);
+            return $translated_buffer;
+          }
         }
       }
 

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -33,15 +33,18 @@
     ob_start(function($buffer) use ($headers, $store) {
       $headers->responseOut();
 
-      if(!empty($buffer) && Utils::isHtml($buffer)) {
-        if (!$store->settings['check_amp'] || !Utils::isAmp($buffer)) {
-          $translated_buffer = API::translate($store, $headers, $buffer);
+      if (empty($buffer) || !Utils::isHtml($buffer)) {
+        return $buffer;
+      }
 
-          if ($translated_buffer !== NULL && !empty($translated_buffer)) {
-            Utils::changeHeaders($translated_buffer, $store);
-            return $translated_buffer;
-          }
-        }
+      if ($store->settings['check_amp'] && Utils::isAmp($buffer)) {
+        return $buffer;
+      }
+
+      $translated_buffer = API::translate($store, $headers, $buffer);
+      if ($translated_buffer !== NULL && !empty($translated_buffer)) {
+        Utils::changeHeaders($translated_buffer, $store);
+        return $translated_buffer;
       }
 
       return $buffer;

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -80,6 +80,12 @@
         'use_server_error_settings' => false,
         'disable_api_request_for_default_lang' => false,
 
+        // Set to true to check if intercepted file is an AMP file.
+        // Because WOVN.php interception is explicit, in most cases AMP files
+        // are not intercepted, so this option is false by default -- always
+        // checking for AMP takes time we can spare.
+        'check_amp' => false,
+
         // without knowing much about this feature, no one should use this.
         'save_memory_by_sending_wovn_ignore_content' => false
       );

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -34,6 +34,25 @@ class Utils {
     }
   }
 
+  public static function isHtml($buffer) {
+    return $buffer != strip_tags($buffer);
+  }
+
+  public static function isAmp($buffer) {
+    if(preg_match('/<html\s[^>]*(amp|\x{26a1})/siu', $buffer) === 1) {
+      // remove comments to avoid looking at commented html tags (regex must be non-greedy)
+      $uncommentedHtml = preg_replace('/<!--.*?-->/s', '', $buffer);
+      preg_match_all('/<html(?P<args>[^>]*)>/si', $uncommentedHtml, $htmlTags);
+      $htmlMatchCount = count($htmlTags['args']);
+
+      if($htmlMatchCount > 0) {
+        return preg_match('/(^|\s)(amp|\x{26a1})(=|\s|$)/u', $htmlTags['args'][0]) === 1;
+      }
+    }
+
+    return false;
+  }
+
   public static function isFilePathURI($uri) {
     return $uri && (preg_match(self::IMAGE_FILE_PATTERN, $uri) ||
         preg_match(self::AUDIO_FILE_PATTERN, $uri) ||

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -33,29 +33,29 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testIsHtml() {
-	  $this->assertEquals(false, Utils::isHtml('this is not html, even tho it contains < and >'));
+    $this->assertEquals(false, Utils::isHtml('this is not html, even tho it contains < and >'));
 
-	  $this->assertEquals(true, Utils::isHtml('<html><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(true, Utils::isHtml('<p>this is html</p>'));
+    $this->assertEquals(true, Utils::isHtml('<html><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isHtml('<p>this is html</p>'));
   }
 
   public function testIsAmp() {
-	  $this->assertEquals(false, Utils::isAmp('<html><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(false, Utils::isAmp('<htmlnop amp><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(false, Utils::isAmp('<html><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(false, Utils::isAmp('<htmlnop amp><head></head><body><p>this is html</p></body></html>'));
 
-	  $this->assertEquals(true, Utils::isAmp('<html amp><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(true, Utils::isAmp('<html amp ><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(true, Utils::isAmp('<html amp=""><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(true, Utils::isAmp("<html\namp><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp('<html lang=en amp><head></head><body><p>this is html</p></body></html>'));
-	  $this->assertEquals(true, Utils::isAmp('<html amp lang=en><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isAmp('<html amp><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isAmp('<html amp ><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isAmp('<html amp=""><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isAmp("<html\namp><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp('<html lang=en amp><head></head><body><p>this is html</p></body></html>'));
+    $this->assertEquals(true, Utils::isAmp('<html amp lang=en><head></head><body><p>this is html</p></body></html>'));
 
-	  $this->assertEquals(true, Utils::isAmp("<html ⚡><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp("<html ⚡ ><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp("<html ⚡=\"\"><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp("<html\n⚡><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp("<html lang=en ⚡><head></head><body><p>this is html</p></body></html>"));
-	  $this->assertEquals(true, Utils::isAmp("<html ⚡ lang=en><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html ⚡><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html ⚡ ><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html ⚡=\"\"><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html\n⚡><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html lang=en ⚡><head></head><body><p>this is html</p></body></html>"));
+    $this->assertEquals(true, Utils::isAmp("<html ⚡ lang=en><head></head><body><p>this is html</p></body></html>"));
   }
 
   public function testIsAmpWithCommentedHtmlTag() {
@@ -96,11 +96,11 @@ XML;
   </html>
 XML;
 
-	  $this->assertEquals(false, Utils::isAmp($commented_amp));
-	  $this->assertEquals(false, Utils::isAmp($commented_amp_symbol));
+    $this->assertEquals(false, Utils::isAmp($commented_amp));
+    $this->assertEquals(false, Utils::isAmp($commented_amp_symbol));
 
-	  $this->assertEquals(true, Utils::isAmp($uncommented_amp));
-	  $this->assertEquals(true, Utils::isAmp($uncommented_amp_symbol));
-	  $this->assertEquals(true, Utils::isAmp($uncommented_amp_with_multiline_comment));
+    $this->assertEquals(true, Utils::isAmp($uncommented_amp));
+    $this->assertEquals(true, Utils::isAmp($uncommented_amp_symbol));
+    $this->assertEquals(true, Utils::isAmp($uncommented_amp_with_multiline_comment));
   }
 }

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -25,10 +25,82 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('Wovnio\Wovnphp\Headers', get_class($headers));
   }
 
-  public function testisFilePathURI() {
+  public function testIsFilePathURI() {
     $this->assertEquals(false, Utils::isFilePathURI('https://google.com'));
     $this->assertEquals(false, Utils::isFilePathURI('https://google.com/mp3'));
     $this->assertEquals(true, Utils::isFilePathURI('/test.mp3'));
     $this->assertEquals(true, Utils::isFilePathURI('/lvl1/lvl2/file.pdf'));
+  }
+
+  public function testIsHtml() {
+	  $this->assertEquals(false, Utils::isHtml('this is not html, even tho it contains < and >'));
+
+	  $this->assertEquals(true, Utils::isHtml('<html><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(true, Utils::isHtml('<p>this is html</p>'));
+  }
+
+  public function testIsAmp() {
+	  $this->assertEquals(false, Utils::isAmp('<html><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(false, Utils::isAmp('<htmlnop amp><head></head><body><p>this is html</p></body></html>'));
+
+	  $this->assertEquals(true, Utils::isAmp('<html amp><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(true, Utils::isAmp('<html amp ><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(true, Utils::isAmp('<html amp=""><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(true, Utils::isAmp("<html\namp><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp('<html lang=en amp><head></head><body><p>this is html</p></body></html>'));
+	  $this->assertEquals(true, Utils::isAmp('<html amp lang=en><head></head><body><p>this is html</p></body></html>'));
+
+	  $this->assertEquals(true, Utils::isAmp("<html ⚡><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp("<html ⚡ ><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp("<html ⚡=\"\"><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp("<html\n⚡><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp("<html lang=en ⚡><head></head><body><p>this is html</p></body></html>"));
+	  $this->assertEquals(true, Utils::isAmp("<html ⚡ lang=en><head></head><body><p>this is html</p></body></html>"));
+  }
+
+  public function testIsAmpWithCommentedHtmlTag() {
+    $commented_amp = <<<XML
+  <!-- <html amp> -->
+  <html>
+    <head></head>
+    <body></body>
+  </html>
+XML;
+    $commented_amp_symbol = <<<XML
+  <!-- <html ⚡> -->
+  <html>
+    <head></head>
+    <body></body>
+  </html>
+XML;
+    $uncommented_amp = <<<XML
+  <!-- <html> -->
+  <html amp>
+    <head></head>
+    <body></body>
+  </html>
+XML;
+    $uncommented_amp_symbol = <<<XML
+  <!-- <html> -->
+  <html ⚡>
+    <head></head>
+    <body></body>
+  </html>
+XML;
+    $uncommented_amp_with_multiline_comment = <<<XML
+  <!-- <html>
+  -->
+  <html amp>
+    <head></head>
+    <body></body>
+  </html>
+XML;
+
+	  $this->assertEquals(false, Utils::isAmp($commented_amp));
+	  $this->assertEquals(false, Utils::isAmp($commented_amp_symbol));
+
+	  $this->assertEquals(true, Utils::isAmp($uncommented_amp));
+	  $this->assertEquals(true, Utils::isAmp($uncommented_amp_symbol));
+	  $this->assertEquals(true, Utils::isAmp($uncommented_amp_with_multiline_comment));
   }
 }


### PR DESCRIPTION
Add setting for checking and ignoring AMP files

If the intercepted file is an AMP file, it can be ignored by WOVN.php and content should not be changed. Because WOVN.php interception is explicit most of the time (user controls what to intercept), I made it an option that is disabled by default.

Because WOVN.php avoids using HTML parser most of the time, and because this feature is disabled by default I am using regexps too.