### PR TITLE
Default language code alias

### DIFF
--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -233,7 +233,7 @@ class HtmlConverter
   }
 
   private function buildHrefLang($lang_code) {
-    $url = $this->headers->url;
+    $url = $this->headers->urlKeepTrailingSlash;
 
     $defaultLangAlias = $this->store->defaultLangAlias();
     if ($defaultLangAlias) {

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -234,8 +234,15 @@ class HtmlConverter
 
   private function buildHrefLang($lang_code) {
     $url = $this->headers->url;
-    if ($lang_code !== $this->store->settings['default_lang']) {
+
+    $defaultLangAlias = $this->store->defaultLangAlias();
+    if ($defaultLangAlias) {
+      $url = $this->headers->removeLang($url);
       $url = Url::addLangCode($url, $this->store, $lang_code, $this->headers);
+    } else {
+      if ($lang_code !== $this->store->defaultLang()) {
+        $url = Url::addLangCode($url, $this->store, $lang_code, $this->headers);
+      }
     }
     return htmlentities($url);
   }

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -9,7 +9,7 @@
   class API {
     public static function url($store, $headers, $original_content) {
       $token = $store->settings['project_token'];
-      $path = $headers->pathname;
+      $path = $headers->pathnameKeepTrailingSlash;
       $lang = $headers->lang();
       $body_hash = md5($original_content);
       ksort($store->settings);
@@ -38,7 +38,7 @@
 
       $timeout = $store->settings['api_timeout'];
       $data = array(
-        'url' => $headers->url,
+        'url' => $headers->urlKeepTrailingSlash,
         'token' => $token,
         'lang_code' => $headers->lang(),
         'url_pattern' => $store->settings['url_pattern_name'],

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -320,6 +320,7 @@
 
     /**
      * Public function removing the lang of the url
+     * Notice: if there is default language code in custom language code, keep language code url
      *
      * @param String $uri The url with the lang
      * @param String $lang The lang to remove
@@ -331,7 +332,14 @@
       }
 
       $lang_code = $this->store->convertToCustomLangCode($lang);
-      return Url::removeLangCode($uri, $this->store->settings['url_pattern_name'], $lang_code);
+      $default_lang = $this->store->settings['default_lang'];
+      $aliases = $this->store->settings['custom_lang_aliases'];
+      if (array_key_exists($default_lang, $aliases)) {
+        $no_lang_uri = Url::removeLangCode($uri, $this->store->settings['url_pattern_name'], $lang_code);
+        return Url::addLangCode($no_lang_uri, $this->store, $default_lang, $this);
+      } else {
+        return Url::removeLangCode($uri, $this->store->settings['url_pattern_name'], $lang_code);
+      }
     }
 
     /**

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -81,8 +81,10 @@
         $this->query = '';
       }
       $this->query = $this->removeLang($this->query, $this->lang());
+      $this->pathnameKeepTrailingSlash = $this->pathname;
       $this->pathname = preg_replace('/\/$/', '', $this->pathname);
       $this->url = $this->protocol . '://' . $this->host . $this->pathname . $urlQuery;
+      $this->urlKeepTrailingSlash = $this->protocol . '://' . $this->host . $this->pathnameKeepTrailingSlash . $urlQuery;
       if (isset($store->settings['query']) && !empty($store->settings['query'])) {
         $this->redisUrl = $this->host . $this->pathname . $this->matchQuery($urlQuery, $store->settings['query']);
       } else {

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -177,4 +177,14 @@
 
       return $lang_code;
     }
+
+    public function defaultLangAlias() {
+      $defaultLang = $this->defaultLang();
+      return array_key_exists($defaultLang, $this->settings['custom_lang_aliases']) &&
+        $this->settings['custom_lang_aliases'][$defaultLang];
+    }
+
+    public function defaultLang() {
+        return $this->settings['default_lang'];
+    }
   }

--- a/src/wovnio/wovnphp/Url.php
+++ b/src/wovnio/wovnphp/Url.php
@@ -40,6 +40,12 @@ class Url {
     $no_lang_uri = self::removeLangCode($uri, $pattern, $lang_code);
     $no_lang_host = self::removeLangCode($headers->host, $pattern, $lang_code);
 
+    if ($store->defaultLangAlias()) {
+        $default_lang = $store->settings['default_lang'];
+        $no_lang_uri = self::removeLangCode($no_lang_uri, $pattern, $default_lang);
+        $no_lang_host = self::removeLangCode($no_lang_host, $pattern, $default_lang);
+    }
+
     // absolute urls
     if (preg_match('/^(https?:)?\/\//i', $no_lang_uri)) {
       // only to use with absolute urls!!

--- a/test/fixtures/basic_html/insert_hreflang_default_lang_alias.html
+++ b/test/fixtures/basic_html/insert_hreflang_default_lang_alias.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/ct/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/cs/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;version=WOVN.php" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias_trailing_slash.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias_trailing_slash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/en/dir1/dir2/"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/ct/dir1/dir2/"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/cs/dir1/dir2/"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;version=WOVN.php" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected_lang_alias.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_lang_alias.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><link rel="alternate" hreflang="en" href="http://ja.localhost/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hant" href="http://ja.localhost/ct/t.php?hey=yo"><link rel="alternate" hreflang="zh-Hans" href="http://ja.localhost/cs/t.php?hey=yo"><script src="//j.wovn.io/1" data-wovnio="key=toK3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;version=WOVN.php" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_lang_alias.html
+++ b/test/fixtures/basic_html/insert_hreflang_lang_alias.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -751,6 +751,28 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
+  public function testInsertHreflangWithDefaultCustomLangAliasAndTrailingSlash()
+  {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    $env['REQUEST_URI'] = '/dir1/dir2/';
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
+    $store->settings['default_lang'] = 'en';
+    $store->settings['supported_langs'] = array('en', 'zh-CHT', 'zh-CHS');
+    $store->settings['custom_lang_aliases'] = array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct');
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias_trailing_slash.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
   private function executeConvert($converter, $html, $charset, $name)
   {
     $dom = SimpleHtmlDom::str_get_html($html, $charset, false, false, $charset, false);

--- a/test/html/HtmlConverterTest.php
+++ b/test/html/HtmlConverterTest.php
@@ -709,6 +709,48 @@ bye
     $this->assertEquals($expected_html_text, $translated_html);
   }
 
+  public function testInsertHreflangWithCustomLangAlias()
+  {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_lang_alias.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
+    $store->settings['default_lang'] = 'en';
+    $store->settings['supported_langs'] = array('en', 'zh-CHT', 'zh-CHS');
+    $store->settings['custom_lang_aliases'] = array('zh-CHS' => 'cs', 'zh-CHT' => 'ct');
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_lang_alias.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
+  public function testInsertHreflangWithDefaultCustomLangAlias()
+  {
+    libxml_use_internal_errors(true);
+    $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+    $token = 'toK3n';
+
+    $env = $this->getEnv();
+    list($store, $headers) = StoreAndHeaderHelper::create($env);
+    $store->settings['default_lang'] = 'en';
+    $store->settings['supported_langs'] = array('en', 'zh-CHT', 'zh-CHS');
+    $store->settings['custom_lang_aliases'] = array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct');
+    $store->settings['url_pattern_name'] = 'path';
+
+    $converter = new HtmlConverter($html, 'UTF-8', $token, $store, $headers);
+    list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+    $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias.html');
+
+    $this->assertEquals($expected_html_text, $translated_html);
+  }
+
   private function executeConvert($converter, $html, $charset, $name)
   {
     $dom = SimpleHtmlDom::str_get_html($html, $charset, false, false, $charset, false);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
Relate: https://github.com/WOVNio/equalizer/issues/10291 (issue)
https://github.com/WOVNio/WOVN.php/pull/37
https://github.com/WOVNio/html-swapper/pull/167
https://github.com/WOVNio/equalizer/pull/10598

AT
If user set custome language aliases with default language code, should be do following behavior
```
# langauge code aliases
en => en
zh-CHS => tc
```
- when /en/, display English content
- when /tc/, display simple Chinese and read local file en/dir/file (not dir/file)
- when /th/, display Thai content and read local file en/dir/file (not dir/file)
- in above three case, if html-swapper does not reply response, render hreflangs that include /en/, /tc/ and /th/

### Comments

This PR include fix bug about trailing slash.
- keep trailing slash for hreflang
- keep trailing slash to send to html-swaper about url parameter

### Release comments (new feature)
