### PR TITLE
Fix wovn_index_sample.php to not include query parameters during filepath lookup

### DIFF
--- a/hack/run_integration_test.sh
+++ b/hack/run_integration_test.sh
@@ -28,6 +28,13 @@ diff /tmp/result.txt integration_test/amp_expected.html
 
 # STATIC CONTENT INTERCEPTION
 
+mod_rewrite_activation="a2enmod rewrite"
+if [ "${docker_name}" == "php:5.3-apache" ]; then
+  mod_rewrite_activation="${mod_rewrite_activation}; apache2 -D FOREGROUND"
+else
+  mod_rewrite_activation="${mod_rewrite_activation}; apache2-foreground"
+fi
+
 docker ps | grep -v CONTAINER | cut -d " " -f 1 | xargs docker kill || true
 
 docker run -d -p 80:80 -v $(pwd):/var/www/html/WOVN.php \
@@ -35,7 +42,7 @@ docker run -d -p 80:80 -v $(pwd):/var/www/html/WOVN.php \
                        -v $(pwd)/wovn_index_sample.php:/var/www/html/wovn_index.php \
                        -v $(pwd)/integration_test:/var/www/html \
                        ${docker_name} \
-                       /bin/bash -c 'a2enmod rewrite; apache2 -D FOREGROUND'
+                       /bin/bash -c "${mod_rewrite_activation}"
 
 waitServerUp
 

--- a/hack/run_integration_test.sh
+++ b/hack/run_integration_test.sh
@@ -25,3 +25,19 @@ diff /tmp/result.txt integration_test/index_expected.html
 
 curl "localhost/amp.php" -o /tmp/result.txt
 diff /tmp/result.txt integration_test/amp_expected.html
+
+# STATIC CONTENT INTERCEPTION
+
+docker ps | grep -v CONTAINER | cut -d " " -f 1 | xargs docker kill || true
+
+docker run -d -p 80:80 -v $(pwd):/var/www/html/WOVN.php \
+                       -v $(pwd)/htaccess_sample:/var/www/html/.htaccess \
+                       -v $(pwd)/wovn_index_sample.php:/var/www/html/wovn_index.php \
+                       -v $(pwd)/integration_test:/var/www/html \
+                       ${docker_name} \
+                       /bin/bash -c 'a2enmod rewrite; apache2 -D FOREGROUND'
+
+waitServerUp
+
+curl "localhost/static.html?a=b" -o /tmp/result.txt
+diff /tmp/result.txt integration_test/static_expected.html

--- a/integration_test/static.html
+++ b/integration_test/static.html
@@ -1,0 +1,6 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Static Content</h1>
+  </body>
+</html>

--- a/integration_test/static_expected.html
+++ b/integration_test/static_expected.html
@@ -1,0 +1,6 @@
+<html>
+  <head><link rel="alternate" hreflang="ja" href="http://localhost/static.html?a=b&amp;wovn=ja"><link rel="alternate" hreflang="fr" href="http://localhost/static.html?a=b&amp;wovn=fr"><link rel="alternate" hreflang="bg" href="http://localhost/static.html?a=b&amp;wovn=bg"><link rel="alternate" hreflang="en" href="http://localhost/static.html?a=b"><script src="//j.wovn.io/1" data-wovnio="key=Tek3n&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;version=WOVN.php" async></script></head>
+  <body>
+    <h1>Static Content</h1>
+  </body>
+</html>

--- a/wovn_index_sample.php
+++ b/wovn_index_sample.php
@@ -13,7 +13,7 @@ $files = array(
   "index.phtml",
   "app.php"
 );
-$paths = wovn_helper_detect_paths(dirname(__FILE__), $_SERVER["REQUEST_URI"], $files);
+$paths = wovn_helper_detect_paths(dirname(__FILE__), parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH), $files);
 $included = wovn_helper_include_by_paths($paths);
 
 # Set 404 status code if file not included


### PR DESCRIPTION
### Purpose/goal of PR
Fix `wovn_index_sample.php` to not include query parameters during filepath lookup

### Comments
Because `$_SERVER['REQUEST_URI']` may contain query parameters, looking for filepath to include may fail and will fallback to displaying content of index file instead of actual file.