### PR TITLE
Add PHP evaluation with SSI support

### DIFF
--- a/src/wovnio/wovnphp/SSI.php
+++ b/src/wovnio/wovnphp/SSI.php
@@ -11,7 +11,7 @@
     public static function readFileRecursive($includePath, $rootDir, &$limit) {
       $ssi_include_regexp = '/<!--#include virtual="(.+?)"\s*-->/';
       $includeDir = dirname($includePath);
-      $code = file_get_contents($includePath);
+      $code = self::get_contents($includePath);
 
       while (preg_match($ssi_include_regexp, $code)) {
         $code = preg_replace_callback($ssi_include_regexp, function($match) use ($rootDir, $includeDir, $limit) {
@@ -37,5 +37,14 @@
       }
 
       return $code;
+    }
+
+    private static function get_contents($includePath) {
+      ob_start();
+      include $includePath;
+      $contents = ob_get_contents();
+      ob_end_clean();
+
+      return $contents;
     }
   }

--- a/src/wovnio/wovnphp/SSI.php
+++ b/src/wovnio/wovnphp/SSI.php
@@ -42,9 +42,7 @@
     private static function get_contents($includePath) {
       ob_start();
       include $includePath;
-      $contents = ob_get_contents();
-      ob_end_clean();
 
-      return $contents;
+      return ob_get_clean();
     }
   }

--- a/test/WovnIndexSampleTest.php
+++ b/test/WovnIndexSampleTest.php
@@ -32,16 +32,33 @@ class WovnIndexSampleTest extends PHPUnit_Framework_TestCase {
     chdir($this->original_dir);
   }
 
+  protected function setUpSSI () {
+    $indexFile = dirname(__FILE__) . '/wovn_index_sample_workspace/wovn_index.php';
+    $inclusion = '\$included\ =\ wovn_helper_include_by_paths\(\$paths\)\;';
+    $ssiInclusion = '\$included\ =\ wovn_helper_include_by_paths_with_ssi\(\$paths\)\;';
+
+    exec('sed -i -e s/^' . $inclusion .'$/#\ ' . $inclusion . '/ ' . $indexFile);
+    exec('sed -i -e s/^#\ ' . $ssiInclusion . '$/' . $ssiInclusion . '/ ' . $indexFile);
+  }
+
+  protected function tearDownSSI () {
+    unlink('wovn_index.php-e');
+  }
+
   public function testWithFile () {
     $this->touch('index.html');
     $this->assertEquals('This is index.html', $this->runWovnIndex('/index.html'));
   }
 
-  public function testWithSSI () {
-    $this->touch('ssi.html', 'ssi <!--#include virtual="include.html" -->');
+  public function testWithSSIAndPHP () {
+    $this->setUpSSI();
+
+    $this->touch('ssi.html', '<?php echo \'ssi\'; ?> <!--#include virtual="include.html" -->');
     $this->touch('include.html', 'include <!--#include virtual="nested.html" -->');
     $this->touch('nested.html');
     $this->assertEquals('ssi include This is nested.html', $this->runWovnIndex('/ssi.html'));
+
+    $this->tearDownSSI();
   }
 
   public function testDetectIndexPhp () {

--- a/test/WovnIndexSampleTest.php
+++ b/test/WovnIndexSampleTest.php
@@ -42,7 +42,11 @@ class WovnIndexSampleTest extends PHPUnit_Framework_TestCase {
   }
 
   protected function tearDownSSI () {
-    unlink('wovn_index.php-e');
+    $wovnIndexSedBackupFilepath = dirname(__FILE__) . '/wovn_index_sample_workspace/wovn_index.php-e';
+
+    if (file_exists($wovnIndexSedBackupFilepath)) {
+      unlink('wovn_index.php-e');
+    }
   }
 
   public function testWithFile () {

--- a/wovn_index_sample.php
+++ b/wovn_index_sample.php
@@ -13,8 +13,9 @@ $files = array(
   "app.php"
 );
 $paths = wovn_helper_detect_paths(dirname(__FILE__), parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH), $files);
-#$included = wovn_helper_include_by_paths($paths); # this is faster than`wovn_helper_include_by_paths_with_ssi`
-$included = wovn_helper_include_by_paths_with_ssi($paths);
+# SSI USER: please swap comments on the two lines below
+$included = wovn_helper_include_by_paths($paths);
+# $included = wovn_helper_include_by_paths_with_ssi($paths);
 
 # Set 404 status code if file not included
 if (!$included) {


### PR DESCRIPTION
### Purpose/goal of PR
Evaluate PHP with SSI suppor

### Comments
`file_get_contents` which is used for SSI support does not evaluate PHP
code within `<?php` and `?>`. This commit uses `include` instead of
`file_get_contents`, which evaluate PHP code.