### PR TITLE
Coding Standard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
       - save_cache:
           key: vendor-{{ checksum "composer.lock" }}
           paths: vendor
+      - run: ./vendor/bin/phpcs
       - run: scripts/run_phpunit_tests.sh vectorface/php5.3
       - run: scripts/run_phpunit_tests.sh vectorface/php5.4
       - run: scripts/run_phpunit_tests.sh php:5.5-apache

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 .DS_STORE
+.phplint-cache
 .idea/
 vendor/
 composer.phar

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="WOVNio">
+  <arg value="s" /> <!-- show sniff codes in all reports -->
+  <arg value="p" /> <!-- show progress of the run -->
   <arg name="colors" />
 
   <file>./</file>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<ruleset name="WOVNio">
+  <arg name="colors" />
+
+  <file>./</file>
+  <exclude-pattern>./vendor</exclude-pattern>
+  <!-- TODO: fix excluded files below -->
+  <exclude-pattern>./src/wovn_helper.php</exclude-pattern>
+  <exclude-pattern>./src/wovn_interceptor.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/html/HtmlConverter.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/html/HtmlReplaceMarker.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/modified_vendor/SimpleHtmlDom.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/modified_vendor/SimpleHtmlDomNode.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/utils/request_handlers/AbstractRequestHandler.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/utils/request_handlers/CurlRequestHandler.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/utils/request_handlers/RequestHandlerFactory.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/API.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/Headers.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/Lang.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/SSI.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/Store.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/Url.php</exclude-pattern>
+  <exclude-pattern>./src/wovnio/wovnphp/Utils.php</exclude-pattern>
+  <exclude-pattern>./test/helpers/EnvFactory.php</exclude-pattern>
+  <exclude-pattern>./test/helpers/HeadersMock.php</exclude-pattern>
+  <exclude-pattern>./test/helpers/StoreAndHeadersFactory.php</exclude-pattern>
+  <exclude-pattern>./test/integration/SSIWovnIndexSampleTest.php</exclude-pattern>
+  <exclude-pattern>./test/integration/WovnIndexSampleTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/APITest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/HeadersTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/html/HtmlConverterTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/html/HtmlReplaceMakerTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/LangTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/modified_vendor/SimpleHtmlDomTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/SSITest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/StoreTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/UrlTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/utils/request_handlers/CurlRequestHandlerTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/utils/request_handlers/FileGetContentsRequestHandlerTest.php</exclude-pattern>
+  <exclude-pattern>./test/unit/UtilsTest.php</exclude-pattern>
+  <exclude-pattern>./wovn_index_sample.php</exclude-pattern>
+
+  <!-- https://www.php-fig.org/psr/psr-2/ -->
+  <rule ref="PSR2"></rule>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "php": ">=5.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.3.*"
+    "phpunit/phpunit": "4.3.*",
+    "squizlabs/php_codesniffer": "*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e55eb5591cae94e0b516272b1d6d3a0c",
+    "content-hash": "7f82cb4211bdd75304739377e3b6e256",
     "packages": [],
     "packages-dev": [
         {
@@ -757,6 +757,57 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "symfony/yaml",


### PR DESCRIPTION
### Purpose/goal of PR
Start using coding standard for WOVN.php

### Comments
This PR adds PHP_CodeSniffer with PSR2 ruleset in order to force the same coding standard on every `.php` file. PHP_CodeSniffer allows for customizing ruleset, we can include more rules as well as excluding those we don't want.

This PR aims for discussing/setting which standard to use. No code change is included in this PR (current files with lint errors or warning are ignored during analysis).

PSR2 specification: https://www.php-fig.org/psr/psr-2/