### PR TITLE
Changes to Code Standard Rules

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -48,5 +48,16 @@
   </rule>
 
   <!-- https://www.php-fig.org/psr/psr-2/ -->
-  <rule ref="PSR2"></rule>
+  <rule ref="PSR2">
+    <!-- PHP 5.3 doesn't allow calling private method inside anonymous
+         functions, so we use '_' for implicit visibility in some classes -->
+    <exclude name="Squiz.Scope.MethodScope.Missing" />
+    <!-- TODO: Fix and remove once other rules are fixed -->
+    <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+    <exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+  </rule>
+
+  <!-- use camelCase everywhere (PSR2 forces it for class members only) -->
+  <rule ref="Generic.NamingConventions.CamelCapsFunctionName" />
+  <rule ref="Zend.NamingConventions.ValidVariableName" />
 </ruleset>


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
- Ease future PR reviews
- Add rules we already talked about (https://github.com/WOVNio/WOVN.php/pull/48#discussion_r216245788)

### Comments
- Because we are compatible with PHP 5.3, we sometime use "_" for "private
  visibility" because we cannot call actual private functions into anonymous
  functions. Therefore I disabled the rule that forbid it.
- Because fixing all rules + changing indentation all at once make PRs
  difficult to review, I disabled indentation rule temporarily.
- PSR2 does not enforce naming conventions outside of classes, but I
  think we should use the same conventions accross the code so I added
  rules for camelCased function names and variable name outside classes
  too.
