### PR TITLE
Logger

### DIFF
--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -1,6 +1,7 @@
 <?php
   require_once 'wovnio/wovnphp/Headers.php';
   require_once 'wovnio/wovnphp/Lang.php';
+  require_once 'wovnio/wovnphp/Logger.php';
   require_once 'wovnio/wovnphp/Store.php';
   require_once 'wovnio/wovnphp/Utils.php';
   require_once 'wovnio/wovnphp/API.php';

--- a/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
@@ -1,6 +1,8 @@
 <?php
   namespace Wovnio\Utils\RequestHandlers;
 
+  use \Wovnio\Wovnphp\Logger;
+
   abstract class AbstractRequestHandler
   {
 
@@ -22,7 +24,9 @@
             break;
         }
       } catch (\Exception $e) {
-        error_log('****** WOVN++ LOGGER :: Failed to get data from ' . $url . ': ' . $e->getMessage() . ' ******');
+        $errorContext = array('method' => $method, 'url' => $url, 'exception' => $e);
+
+        \Wovnio\Wovnphp\Logger::get()->error('Failed to send {method} request to {url}: {exception}', $errorContext);
       }
 
       return $response;

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -4,8 +4,8 @@
   require_once DIRNAME(__FILE__) . '../../utils/request_handlers/RequestHandlerFactory.php';
 
   use \Wovnio\Wovnphp\Logger;
-  use Wovnio\Html\HtmlConverter;
-  use Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
+  use \Wovnio\Html\HtmlConverter;
+  use \Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
   if (!defined('WOVN_PHP_VERSION')) {
     define('WOVN_PHP_VERSION', '0.1.10');

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -3,6 +3,7 @@
 
   require_once DIRNAME(__FILE__) . '../../utils/request_handlers/RequestHandlerFactory.php';
 
+  use \Wovnio\Wovnphp\Logger;
   use Wovnio\Html\HtmlConverter;
   use Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
@@ -74,7 +75,8 @@
           return $marker->revert($converted_html);
         }
       } catch (\Exception $e) {
-        error_log('****** WOVN++ LOGGER :: Failed to get translated content: ' . $e->getMessage() . ' ******');
+        Logger::get()->error('Failed to get translated content: {exception}.', array('exception' => $e));
+
         return $marker->revert($converted_html);
       }
     }

--- a/src/wovnio/wovnphp/Logger.php
+++ b/src/wovnio/wovnphp/Logger.php
@@ -10,8 +10,8 @@ class Logger
 {
   private static $logger = null;
 
-  public $prefix;
-  public $quiet;
+  private $prefix;
+  private $quiet;
 
   public static function get()
   {
@@ -30,6 +30,26 @@ class Logger
   public function __construct($quiet = false, $prefix = 'WOVN.php')
   {
     $this->prefix = $prefix;
+    $this->quiet = $quiet;
+  }
+
+  public function getPrefix()
+  {
+    return $this->prefix;
+  }
+
+  public function setPrefix($prefix)
+  {
+    $this->prefix = $prefix;
+  }
+
+  public function getQuiet()
+  {
+    return $this->quiet;
+  }
+
+  public function setQuiet($quiet)
+  {
     $this->quiet = $quiet;
   }
 

--- a/src/wovnio/wovnphp/Logger.php
+++ b/src/wovnio/wovnphp/Logger.php
@@ -1,0 +1,97 @@
+<?php
+namespace Wovnio\Wovnphp;
+
+/**
+ * Logger implementation inspired by PSR3: https://www.php-fig.org/psr/psr-3/.
+ * Unlike PSR3, the `log` function is private and there are no constants for
+ * representing log levels.
+ */
+class Logger
+{
+  private static $logger = null;
+
+  public $prefix;
+  public $quiet;
+
+  public static function get()
+  {
+    if (self::$logger === null) {
+      self::$logger = new Logger();
+    }
+
+    return self::$logger;
+  }
+
+  public static function set($logger)
+  {
+    self::$logger = $logger;
+  }
+
+  public function __construct($quiet = false, $prefix = 'WOVN.php')
+  {
+    $this->prefix = $prefix;
+    $this->quiet = $quiet;
+  }
+
+  public function emergency($message, $context = array())
+  {
+    $this->log('EMERGENCY', $message, $context);
+  }
+
+  public function alert($message, $context = array())
+  {
+    $this->log('ALERT', $message, $context);
+  }
+
+  public function critical($message, $context = array())
+  {
+    $this->log('CRITICAL', $message, $context);
+  }
+
+  public function error($message, $context = array())
+  {
+    $this->log('ERROR', $message, $context);
+  }
+
+  public function warning($message, $context = array())
+  {
+    $this->log('WARNING', $message, $context);
+  }
+
+  public function notice($message, $context = array())
+  {
+    $this->log('NOTICE', $message, $context);
+  }
+
+  public function info($message, $context = array())
+  {
+    $this->log('INFO', $message, $context);
+  }
+
+  public function debug($message, $context = array())
+  {
+    $this->log('DEBUG', $message, $context);
+  }
+
+  private function log($level, $message, $context)
+  {
+    if (!$this->quiet) {
+      error_log("$this->prefix [$level] " . $this->interpolate($message, $context));
+    }
+  }
+
+  private function interpolate($message, $context)
+  {
+    $replacements = array();
+
+    foreach ($context as $key => $value) {
+      if ($key === 'exception') {
+        $replacements['{' . $key . '}'] = $value->getMessage();
+      } elseif (!is_array($value) && (!is_object($value) || method_exists($value, '__toString'))) {
+        $replacements['{' . $key . '}'] = $value;
+      }
+    }
+
+    return strtr($message, $replacements);
+  }
+}

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -1,5 +1,7 @@
 <?php
   namespace Wovnio\Wovnphp;
+
+  use \Wovnio\Wovnphp\Logger;
   use Wovnio\Html\HtmlConverter;
 
   /**
@@ -126,7 +128,8 @@
       }
 
       if (isset($vals['encoding']) && in_array($vals['encoding'], HtmlConverter::$supported_encodings) == false) {
-        error_log('****** WOVN++ LOGGER :: Invalid encoding setting: ' . $vals['encoding'] . ' ******');
+        Logger::get()->warning('Invalid encoding setting: {encoding}.', $vals);
+
         $vals['encoding'] = null;
       }
 

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -6,6 +6,7 @@ require_once 'vendor/autoload.php';
 
 require_once 'src/wovnio/wovnphp/Headers.php';
 require_once 'src/wovnio/wovnphp/Lang.php';
+require_once 'src/wovnio/wovnphp/Logger.php';
 require_once 'src/wovnio/wovnphp/Store.php';
 require_once 'src/wovnio/wovnphp/Url.php';
 require_once 'src/wovnio/wovnphp/Utils.php';
@@ -17,3 +18,6 @@ require_once 'src/wovnio/modified_vendor/SimpleHtmlDom.php';
 require_once 'src/wovnio/modified_vendor/SimpleHtmlDomNode.php';
 
 require_once 'test/helpers/StoreAndHeadersFactory.php';
+
+// disable error logging
+\Wovnio\Wovnphp\Logger::set(new \Wovnio\Wovnphp\Logger(true));

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -20,4 +20,4 @@ require_once 'src/wovnio/modified_vendor/SimpleHtmlDomNode.php';
 require_once 'test/helpers/StoreAndHeadersFactory.php';
 
 // disable error logging
-\Wovnio\Wovnphp\Logger::set(new \Wovnio\Wovnphp\Logger(true));
+\Wovnio\Wovnphp\Logger::get()->setQuiet(true);


### PR DESCRIPTION
### Purpose/goal of PR
Add a logger to homogenize log messages and allow to quiet WOVN.php logs.
Format is: `WOVN.php [MESSAGE_TYPE] MESSAGE`.

Inspired by PSR3: https://www.php-fig.org/psr/psr-3/.

### Comments
As current logs, `Logger` uses `error_log` to log messages. In the future, we might consider using `syslog` instead or allow user to set a separate log file for WOVN.php (`error_log('message', 3, 'path/to/custom/log/file')`).

### Release comments
Previous log format was `****** WOVN++ LOGGER :: MESSAGE ******`. If user parse logs, their parsing might no longer work. Do we need to do something about it? Is release change log enough? Or should I put back the logging to this format?
