### PR TITLE
Update Lang with Coding Standard

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -10,11 +10,9 @@
   <exclude-pattern>./src/wovnio/modified_vendor</exclude-pattern>
   <!-- TODO: fix excluded files below -->
   <exclude-pattern>./src/wovn_helper.php</exclude-pattern>
-  <exclude-pattern>./src/wovnio/wovnphp/Lang.php</exclude-pattern>
   <exclude-pattern>./test/integration/SSIWovnIndexSampleTest.php</exclude-pattern>
   <exclude-pattern>./test/integration/WovnIndexSampleTest.php</exclude-pattern>
   <exclude-pattern>./test/unit/html/HtmlReplaceMakerTest.php</exclude-pattern>
-  <exclude-pattern>./test/unit/LangTest.php</exclude-pattern>
   <exclude-pattern>./test/unit/modified_vendor/SimpleHtmlDomTest.php</exclude-pattern>
   <exclude-pattern>./test/unit/UrlTest.php</exclude-pattern>
   <exclude-pattern>./test/unit/utils/request_handlers/CurlRequestHandlerTest.php</exclude-pattern>

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -120,7 +120,7 @@ class HtmlConverter
         $lang_codes = $this->store->settings['supported_langs'];
         foreach ($lang_codes as $lang_code) {
           $href = $this->buildHrefLang($lang_code);
-          array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso639_1Normalization($lang_code) . '" href="' . $href . '">');
+          array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso6391Normalization($lang_code) . '" href="' . $href . '">');
         }
       }
 
@@ -211,7 +211,7 @@ class HtmlConverter
     $hreflangTags = array();
     foreach ($lang_codes as $lang_code) {
       $href = $this->buildHrefLang($lang_code);
-      array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso639_1Normalization($lang_code) . '" href="' . $href . '">');
+      array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso6391Normalization($lang_code) . '" href="' . $href . '">');
     }
 
     $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");

--- a/src/wovnio/wovnphp/Lang.php
+++ b/src/wovnio/wovnphp/Lang.php
@@ -8,7 +8,7 @@ namespace Wovnio\Wovnphp;
  */
 class Lang
 {
-  static $lang = array(
+  const INDEX = array(
     'ar' => array('name' => 'العربية',          'code' => 'ar',     'iso639-1' => 'ar',      'en' => 'Arabic'),
     'eu' => array('name' => 'Euskara',          'code' => 'eu',     'iso639-1' => 'eu',      'en' => 'Basque'),
     'bn' => array('name' => 'বাংলা ভাষা',          'code' => 'bn',     'iso639-1' => 'bn',      'en' => 'Bengali'),
@@ -66,11 +66,11 @@ class Lang
 
     $lang_code = $store->convertToOriginalCode($lang_code);
 
-    if (isset(Lang::$lang[$lang_code])) {
+    if (Lang::INDEX[$lang_code] !== null) {
       return $lang_code;
     }
 
-    foreach (Lang::$lang as $lang) {
+    foreach (self::INDEX as $lang) {
       if (strtolower($lang_code) === strtolower($lang['code'])) {
         return $lang['code'];
       }
@@ -90,10 +90,10 @@ class Lang
     if ($lang_name === null) {
       return null;
     }
-    if (isset(Lang::$lang[$lang_name])) {
+    if (self::INDEX[$lang_name] !== null) {
       return $lang_name;
     }
-    foreach (Lang::$lang as $lang) {
+    foreach (self::INDEX as $lang) {
       if (strtolower($lang_name) === strtolower($lang['name']) || strtolower($lang_name) === strtolower($lang['en']) || strtolower($lang_name) === strtolower($lang['code']) || strtolower($lang_name) === strtolower($lang['iso639-1'])) {
         return $lang['code'];
       }
@@ -109,7 +109,7 @@ class Lang
   public static function getEnglishNamesArray()
   {
     $englishNamesArray = array();
-    foreach (Lang::$lang as $lang) {
+    foreach (self::INDEX as $lang) {
       array_push($englishNamesArray, $lang['en']);
     }
     return $englishNamesArray;
@@ -123,13 +123,12 @@ class Lang
    *
    * @return String The ISO639-1 code of the language.
    */
-  public static function iso639_1Normalization($lang_code)
+  public static function iso6391Normalization($lang_code)
   {
-    if (isset(Lang::$lang[$lang_code])) {
-      return Lang::$lang[$lang_code]['iso639-1'];
+    if (self::INDEX[$lang_code] !== null) {
+      return self::INDEX[$lang_code]['iso639-1'];
     } else {
       return null;
     }
   }
 }
-

--- a/src/wovnio/wovnphp/Lang.php
+++ b/src/wovnio/wovnphp/Lang.php
@@ -8,7 +8,7 @@ namespace Wovnio\Wovnphp;
  */
 class Lang
 {
-  const INDEX = array(
+  public static $index = array(
     'ar' => array('name' => 'العربية',          'code' => 'ar',     'iso639-1' => 'ar',      'en' => 'Arabic'),
     'eu' => array('name' => 'Euskara',          'code' => 'eu',     'iso639-1' => 'eu',      'en' => 'Basque'),
     'bn' => array('name' => 'বাংলা ভাষা',          'code' => 'bn',     'iso639-1' => 'bn',      'en' => 'Bengali'),
@@ -66,11 +66,11 @@ class Lang
 
     $lang_code = $store->convertToOriginalCode($lang_code);
 
-    if (Lang::INDEX[$lang_code] !== null) {
+    if (self::$index[$lang_code] !== null) {
       return $lang_code;
     }
 
-    foreach (self::INDEX as $lang) {
+    foreach (self::$index as $lang) {
       if (strtolower($lang_code) === strtolower($lang['code'])) {
         return $lang['code'];
       }
@@ -90,10 +90,10 @@ class Lang
     if ($lang_name === null) {
       return null;
     }
-    if (self::INDEX[$lang_name] !== null) {
+    if (self::$index[$lang_name] !== null) {
       return $lang_name;
     }
-    foreach (self::INDEX as $lang) {
+    foreach (self::$index as $lang) {
       if (strtolower($lang_name) === strtolower($lang['name']) || strtolower($lang_name) === strtolower($lang['en']) || strtolower($lang_name) === strtolower($lang['code']) || strtolower($lang_name) === strtolower($lang['iso639-1'])) {
         return $lang['code'];
       }
@@ -109,7 +109,7 @@ class Lang
   public static function getEnglishNamesArray()
   {
     $englishNamesArray = array();
-    foreach (self::INDEX as $lang) {
+    foreach (self::$index as $lang) {
       array_push($englishNamesArray, $lang['en']);
     }
     return $englishNamesArray;
@@ -125,8 +125,8 @@ class Lang
    */
   public static function iso6391Normalization($lang_code)
   {
-    if (self::INDEX[$lang_code] !== null) {
-      return self::INDEX[$lang_code]['iso639-1'];
+    if (self::$index[$lang_code] !== null) {
+      return self::$index[$lang_code]['iso639-1'];
     } else {
       return null;
     }

--- a/src/wovnio/wovnphp/Lang.php
+++ b/src/wovnio/wovnphp/Lang.php
@@ -66,11 +66,11 @@ class Lang
 
     $lang_code = $store->convertToOriginalCode($lang_code);
 
-    if (self::$index[$lang_code] !== null) {
+    if (isset(LANG::$index[$lang_code])) {
       return $lang_code;
     }
 
-    foreach (self::$index as $lang) {
+    foreach (LANG::$index as $lang) {
       if (strtolower($lang_code) === strtolower($lang['code'])) {
         return $lang['code'];
       }
@@ -90,10 +90,10 @@ class Lang
     if ($lang_name === null) {
       return null;
     }
-    if (self::$index[$lang_name] !== null) {
+    if (isset(LANG::$index[$lang_name])) {
       return $lang_name;
     }
-    foreach (self::$index as $lang) {
+    foreach (LANG::$index as $lang) {
       if (strtolower($lang_name) === strtolower($lang['name']) || strtolower($lang_name) === strtolower($lang['en']) || strtolower($lang_name) === strtolower($lang['code']) || strtolower($lang_name) === strtolower($lang['iso639-1'])) {
         return $lang['code'];
       }
@@ -109,7 +109,7 @@ class Lang
   public static function getEnglishNamesArray()
   {
     $englishNamesArray = array();
-    foreach (self::$index as $lang) {
+    foreach (LANG::$index as $lang) {
       array_push($englishNamesArray, $lang['en']);
     }
     return $englishNamesArray;
@@ -125,8 +125,8 @@ class Lang
    */
   public static function iso6391Normalization($lang_code)
   {
-    if (self::$index[$lang_code] !== null) {
-      return self::$index[$lang_code]['iso639-1'];
+    if (isset(LANG::$index[$lang_code])) {
+      return LANG::$index[$lang_code]['iso639-1'];
     } else {
       return null;
     }

--- a/test/helpers/HeadersMock.php
+++ b/test/helpers/HeadersMock.php
@@ -82,7 +82,8 @@ function getHeadersReceivedByHeaderMock()
 
 /** MOCKED FUNCTIONS **********************************************************/
 
-// @codingStandardsIgnoreLine
+// phpcs:disable Squiz.NamingConventions.ValidFunctionName.NotCamelCaps
+
 function headers_sent()
 {
   global $mockHeadersSent;
@@ -95,7 +96,6 @@ function headers_sent()
   }
 }
 
-// @codingStandardsIgnoreLine
 function function_exists($funcName)
 {
   global $mockApacheResponseHeaders;
@@ -108,7 +108,6 @@ function function_exists($funcName)
   }
 }
 
-// @codingStandardsIgnoreLine
 function apache_response_headers()
 {
   global $mockApacheResponseHeaders;
@@ -132,3 +131,5 @@ function header($h)
     return call_user_func_array('\header', func_get_args());
   }
 }
+
+// phpcs:enable

--- a/test/unit/LangTest.php
+++ b/test/unit/LangTest.php
@@ -1,18 +1,23 @@
 <?php
-use Wovnio\Wovnphp\Lang;
+namespace Wovnio\Wovnphp\Tests;
 
-class LangTest extends PHPUnit_Framework_TestCase {
-  public function testLangExist () {
-    $this->assertTrue(class_exists('Wovnio\Wovnphp\Lang'));
-    $this->assertClassHasStaticAttribute("lang", 'Wovnio\Wovnphp\Lang');
+use \Wovnio\Wovnphp\Lang;
+
+class LangTest extends \PHPUnit_Framework_TestCase
+{
+  public function testLangExist()
+  {
+    $this->assertTrue(class_exists('\Wovnio\Wovnphp\Lang'));
   }
 
-  public function testLangLength () {
-    $this->assertEquals(39, count(Lang::$lang));
+  public function testLangLength()
+  {
+    $this->assertEquals(39, count(Lang::INDEX));
   }
 
-  public function testKeysExist () {
-    foreach(Lang::$lang as $key => $lang) {
+  public function testKeysExist()
+  {
+    foreach (Lang::INDEX as $key => $lang) {
       $this->assertArrayHasKey('name', $lang);
       $this->assertArrayHasKey('code', $lang);
       $this->assertArrayHasKey('en', $lang);
@@ -20,76 +25,83 @@ class LangTest extends PHPUnit_Framework_TestCase {
     }
   }
 
-  public function testGetCodeWithValidCode () {
+  public function testGetCodeWithValidCode()
+  {
     $this->assertEquals('ms', Lang::getCode('ms'));
   }
 
-  public function testGetCodeWithValidEnglishName () {
+  public function testGetCodeWithValidEnglishName()
+  {
     $this->assertEquals('pt', Lang::getCode('Portuguese'));
   }
 
-  public function testGetCodeWithValidNativeName () {
+  public function testGetCodeWithValidNativeName()
+  {
     $this->assertEquals('hi', Lang::getCode('हिन्दी'));
   }
 
-  public function testGetCodeWithInvalidName () {
+  public function testGetCodeWithInvalidName()
+  {
     $this->assertEquals(null, Lang::getCode('WOVN4LYFE'));
   }
 
-  public function testGetCodeWithEmptyString () {
+  public function testGetCodeWithEmptyString()
+  {
     $this->assertEquals(null, Lang::getCode(''));
   }
 
-  public function testGetCodeWithNil () {
+  public function testGetCodeWithNil()
+  {
     $this->assertEquals(null, Lang::getCode(null));
   }
 
-  public function testGetEnglishNamesArray () {
+  public function testGetEnglishNamesArray()
+  {
     $array = Lang::getEnglishNamesArray();
     $this->assertTrue(is_array($array));
   }
 
-  public function testISO639_1Normalization () {
-    $this->assertEquals('ar',       Lang::iso639_1Normalization('ar'));
-    $this->assertEquals('eu',       Lang::iso639_1Normalization('eu'));
-    $this->assertEquals('bn',       Lang::iso639_1Normalization('bn'));
-    $this->assertEquals('bg',       Lang::iso639_1Normalization('bg'));
-    $this->assertEquals('ca',       Lang::iso639_1Normalization('ca'));
-    $this->assertEquals('zh-Hans',  Lang::iso639_1Normalization('zh-CHS'));
-    $this->assertEquals('zh-Hant',  Lang::iso639_1Normalization('zh-CHT'));
-    $this->assertEquals('da',       Lang::iso639_1Normalization('da'));
-    $this->assertEquals('nl',       Lang::iso639_1Normalization('nl'));
-    $this->assertEquals('en',       Lang::iso639_1Normalization('en'));
-    $this->assertEquals('fi',       Lang::iso639_1Normalization('fi'));
-    $this->assertEquals('fr',       Lang::iso639_1Normalization('fr'));
-    $this->assertEquals('gl',       Lang::iso639_1Normalization('gl'));
-    $this->assertEquals('de',       Lang::iso639_1Normalization('de'));
-    $this->assertEquals('el',       Lang::iso639_1Normalization('el'));
-    $this->assertEquals('he',       Lang::iso639_1Normalization('he'));
-    $this->assertEquals('hu',       Lang::iso639_1Normalization('hu'));
-    $this->assertEquals('id',       Lang::iso639_1Normalization('id'));
-    $this->assertEquals('it',       Lang::iso639_1Normalization('it'));
-    $this->assertEquals('ja',       Lang::iso639_1Normalization('ja'));
-    $this->assertEquals('ko',       Lang::iso639_1Normalization('ko'));
-    $this->assertEquals('lv',       Lang::iso639_1Normalization('lv'));
-    $this->assertEquals('ms',       Lang::iso639_1Normalization('ms'));
-    $this->assertEquals('my',       Lang::iso639_1Normalization('my'));
-    $this->assertEquals('ne',       Lang::iso639_1Normalization('ne'));
-    $this->assertEquals('no',       Lang::iso639_1Normalization('no'));
-    $this->assertEquals('fa',       Lang::iso639_1Normalization('fa'));
-    $this->assertEquals('pl',       Lang::iso639_1Normalization('pl'));
-    $this->assertEquals('pt',       Lang::iso639_1Normalization('pt'));
-    $this->assertEquals('ru',       Lang::iso639_1Normalization('ru'));
-    $this->assertEquals('es',       Lang::iso639_1Normalization('es'));
-    $this->assertEquals('sw',       Lang::iso639_1Normalization('sw'));
-    $this->assertEquals('sv',       Lang::iso639_1Normalization('sv'));
-    $this->assertEquals('th',       Lang::iso639_1Normalization('th'));
-    $this->assertEquals('hi',       Lang::iso639_1Normalization('hi'));
-    $this->assertEquals('tr',       Lang::iso639_1Normalization('tr'));
-    $this->assertEquals('uk',       Lang::iso639_1Normalization('uk'));
-    $this->assertEquals('ur',       Lang::iso639_1Normalization('ur'));
-    $this->assertEquals('vi',       Lang::iso639_1Normalization('vi'));
-    $this->assertEquals(null,       Lang::iso639_1Normalization('fake'));
+  public function testISO6391Normalization()
+  {
+    $this->assertEquals('ar', Lang::iso6391Normalization('ar'));
+    $this->assertEquals('eu', Lang::iso6391Normalization('eu'));
+    $this->assertEquals('bn', Lang::iso6391Normalization('bn'));
+    $this->assertEquals('bg', Lang::iso6391Normalization('bg'));
+    $this->assertEquals('ca', Lang::iso6391Normalization('ca'));
+    $this->assertEquals('zh-Hans', Lang::iso6391Normalization('zh-CHS'));
+    $this->assertEquals('zh-Hant', Lang::iso6391Normalization('zh-CHT'));
+    $this->assertEquals('da', Lang::iso6391Normalization('da'));
+    $this->assertEquals('nl', Lang::iso6391Normalization('nl'));
+    $this->assertEquals('en', Lang::iso6391Normalization('en'));
+    $this->assertEquals('fi', Lang::iso6391Normalization('fi'));
+    $this->assertEquals('fr', Lang::iso6391Normalization('fr'));
+    $this->assertEquals('gl', Lang::iso6391Normalization('gl'));
+    $this->assertEquals('de', Lang::iso6391Normalization('de'));
+    $this->assertEquals('el', Lang::iso6391Normalization('el'));
+    $this->assertEquals('he', Lang::iso6391Normalization('he'));
+    $this->assertEquals('hu', Lang::iso6391Normalization('hu'));
+    $this->assertEquals('id', Lang::iso6391Normalization('id'));
+    $this->assertEquals('it', Lang::iso6391Normalization('it'));
+    $this->assertEquals('ja', Lang::iso6391Normalization('ja'));
+    $this->assertEquals('ko', Lang::iso6391Normalization('ko'));
+    $this->assertEquals('lv', Lang::iso6391Normalization('lv'));
+    $this->assertEquals('ms', Lang::iso6391Normalization('ms'));
+    $this->assertEquals('my', Lang::iso6391Normalization('my'));
+    $this->assertEquals('ne', Lang::iso6391Normalization('ne'));
+    $this->assertEquals('no', Lang::iso6391Normalization('no'));
+    $this->assertEquals('fa', Lang::iso6391Normalization('fa'));
+    $this->assertEquals('pl', Lang::iso6391Normalization('pl'));
+    $this->assertEquals('pt', Lang::iso6391Normalization('pt'));
+    $this->assertEquals('ru', Lang::iso6391Normalization('ru'));
+    $this->assertEquals('es', Lang::iso6391Normalization('es'));
+    $this->assertEquals('sw', Lang::iso6391Normalization('sw'));
+    $this->assertEquals('sv', Lang::iso6391Normalization('sv'));
+    $this->assertEquals('th', Lang::iso6391Normalization('th'));
+    $this->assertEquals('hi', Lang::iso6391Normalization('hi'));
+    $this->assertEquals('tr', Lang::iso6391Normalization('tr'));
+    $this->assertEquals('uk', Lang::iso6391Normalization('uk'));
+    $this->assertEquals('ur', Lang::iso6391Normalization('ur'));
+    $this->assertEquals('vi', Lang::iso6391Normalization('vi'));
+    $this->assertEquals(null, Lang::iso6391Normalization('fake'));
   }
-
 }

--- a/test/unit/LangTest.php
+++ b/test/unit/LangTest.php
@@ -8,16 +8,17 @@ class LangTest extends \PHPUnit_Framework_TestCase
   public function testLangExist()
   {
     $this->assertTrue(class_exists('\Wovnio\Wovnphp\Lang'));
+    $this->assertClassHasStaticAttribute("index", 'Wovnio\Wovnphp\Lang');
   }
 
   public function testLangLength()
   {
-    $this->assertEquals(39, count(Lang::INDEX));
+    $this->assertEquals(39, count(Lang::$index));
   }
 
   public function testKeysExist()
   {
-    foreach (Lang::INDEX as $key => $lang) {
+    foreach (Lang::$index as $key => $lang) {
       $this->assertArrayHasKey('name', $lang);
       $this->assertArrayHasKey('code', $lang);
       $this->assertArrayHasKey('en', $lang);


### PR DESCRIPTION
### Purpose/goal of PR
Update Lang with coding standard

### Comments
`Lang::$lang` did not have visibility and it is accessed from tests so it needed to be public. I also renamed it into `Lang::$index` instead of `Lang::$lang`. Note that it should be a constant, but PHP 5.3 forbids array constants.

I also fixed in-file rules ignore with latest (most-specific) syntax.