### PR TITLE
Send every setting to translation API

### DIFF
--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -48,15 +48,13 @@ class API
         }
 
         $timeout = $store->settings['api_timeout'];
-        $data = array(
+        $data = array_merge($store->settings, array(
             'url' => $headers->urlKeepTrailingSlash,
-            'token' => $token,
             'lang_code' => $headers->lang(),
-            'url_pattern' => $store->settings['url_pattern_name'],
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_html
-        );
+        ));
 
         if (count($store->settings['custom_lang_aliases']) > 0) {
             $data['custom_lang_aliases'] = json_encode($store->settings['custom_lang_aliases']);

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -90,15 +90,13 @@ class APITest extends \PHPUnit_Framework_TestCase
 
     private function getExpectedData($store, $headers, $converted_body, $extra = array())
     {
-        $data = array(
+        $data = array_merge($store->settings, array(
             'url' => $headers->urlKeepTrailingSlash,
-            'token' => $store->settings['project_token'],
             'lang_code' => $headers->lang(),
-            'url_pattern' => $store->settings['url_pattern_name'],
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_body
-        );
+        ));
 
         return array_merge($data, $extra);
     }


### PR DESCRIPTION
### Purpose/goal of PR
Send every setting to translation API

### Comments
In future, implementation of translation API may require settings set on backend side. For that reason, and to avoid setting specific settings every time and asking client to update WOVN.php, all settings are now sent to translation API.
