### PR TITLE
Stop Intercepting .rar and .tar.gz files

### DIFF
--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -6,7 +6,7 @@ class Utils
     const IMAGE_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))(?=([\?#&].*$|$))/i";
     const AUDIO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))(?=([\?#&].*$|$))/i";
     const VIDEO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))(?=([\?#&].*$|$))/i";
-    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((7|g)?zip|tar|rar|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
+    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((7|g)?zip|tar|rar|7z|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
 
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -6,7 +6,7 @@ class Utils
     const IMAGE_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))(?=([\?#&].*$|$))/i";
     const AUDIO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))(?=([\?#&].*$|$))/i";
     const VIDEO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))(?=([\?#&].*$|$))/i";
-    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(zip|tar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
+    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(zip|tar|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
 
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -6,7 +6,7 @@ class Utils
     const IMAGE_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))(?=([\?#&].*$|$))/i";
     const AUDIO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))(?=([\?#&].*$|$))/i";
     const VIDEO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))(?=([\?#&].*$|$))/i";
-    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(zip|tar|rar|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
+    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((7|g)?zip|tar|rar|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
 
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -6,7 +6,7 @@ class Utils
     const IMAGE_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))(?=([\?#&].*$|$))/i";
     const AUDIO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))(?=([\?#&].*$|$))/i";
     const VIDEO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))(?=([\?#&].*$|$))/i";
-    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(zip|tar|rar|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
+    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(zip|tar|rar|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)m?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))(?=([\?#&].*$|$))/i";
 
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -46,6 +46,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, Utils::isFilePathURI('https://google.com', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.zip', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.7zip', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.7z', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.gzip', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.rar', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.tar.gz', $store));

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -45,6 +45,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $store->settings['ignore_regex'] = array("/img\/assets$/i");
         $this->assertEquals(false, Utils::isFilePathURI('https://google.com', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.rar', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.tar.gz', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.jpg', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/assets/img/boop', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/img/assets', $store));

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -44,6 +44,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $store->settings['ignore_paths'] = array('/coucou.jpg', 'assets/img/');
         $store->settings['ignore_regex'] = array("/img\/assets$/i");
         $this->assertEquals(false, Utils::isFilePathURI('https://google.com', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.rar', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.jpg', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/assets/img/boop', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/img/assets', $store));

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -44,6 +44,9 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $store->settings['ignore_paths'] = array('/coucou.jpg', 'assets/img/');
         $store->settings['ignore_regex'] = array("/img\/assets$/i");
         $this->assertEquals(false, Utils::isFilePathURI('https://google.com', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.zip', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.7zip', $store));
+        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.gzip', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.rar', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.tar.gz', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.jpg', $store));


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
Like ZIP and TAR files, RAR and gziped files should not be intercepted.