### PR TITLE
Fix PHP 7.3 error on unescaped dash in regexp

### DIFF
--- a/src/wovnio/modified_vendor/SimpleHtmlDom.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDom.php
@@ -438,7 +438,7 @@ class SimpleHtmlDom {
             return true;
         }
 
-        if (!preg_match("/^[\w-:]+$/", $tag)) {
+        if (!preg_match("/^[\w\-:]+$/", $tag)) {
             $node->info_text = '<' . $tag . $this->copy_until($doc, '<>');
             if ($this->char==='<') {
                 $this->link_nodes($node, false);


### PR DESCRIPTION
### Purpose/goal of PR
fix PHP 7.3 error on unescaped dash in regexp