### PR TITLE
Support HTTP Header X-Forwarded-Request-Uri for when proxy is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,20 @@ requested URL. In that case, you should set `use_proxy` to `1` (true).
 ```
 use_proxy = 1
 ```
+When `use_proxy` is active, WOVN.php will attempt to use URL protocol and host
+from HTTP Headers `X-Forwarded-Proto` and `X-Forwarded-Host`. These are standard
+fields for proxy forwarding.
+
+Furthermore, WOVN.php will look for HTTP Header `X-Forwarded-Request-Uri`. This
+may be manually set in order for WOVN.php to see the original client requested
+URI (i.e "/japan/tokyo.html"). If using mod\_proxy and the ProxyPass directive,
+for example, this HTTP Header may be set with the RequestHeader directive as
+follows
+```apache
+ProxyPass        /japan http://my.subdomain.com
+ProxyPassReverse /japan http://my.subdomain.com
+RequestHeader    setifempty X-Forwarded-Request-Uri "expr=%{REQUEST_URI}"
+```
 
 #### `override_content_length`
 This parameter tell WOVN.php whether or not it should update the response header

--- a/src/version.php
+++ b/src/version.php
@@ -3,5 +3,5 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    define('WOVN_PHP_VERSION', '0.1.12');
+    define('WOVN_PHP_VERSION', '0.1.13');
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -188,7 +188,12 @@ class Headers
             }
             // get the lang in the path
             $rp = '/' . $this->store->settings['url_pattern_reg'] . '/';
-            preg_match($rp, $server_name . $this->env['REQUEST_URI'], $match);
+            if ($this->store->settings['use_proxy'] && isset($this->env['HTTP_X_FORWARDED_REQUEST_URI'])) {
+                $request_uri = $this->env['HTTP_X_FORWARDED_REQUEST_URI'];
+            } else {
+                $request_uri = $this->env['REQUEST_URI'];
+            }
+            preg_match($rp, $server_name . $request_uri, $match);
             if (isset($match['lang'])) {
                 $lang_code = Lang::formatLangCode($match['lang'], $this->store);
                 if (!is_null($lang_code)) {

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -742,20 +742,43 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $pathlang);
     }
 
-    public function testPathLangWithUseProxyTrue()
+    public function testPathLangWithSubdomainAndUseProxyTrue()
     {
         $settings = array(
             'url_pattern_name' => 'subdomain',
             'use_proxy' => 1
         );
-        $env = array('HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co');
+        $env = array(
+            'SERVER_NAME' => 'ja.wovn.io',
+            'REQUEST_URI' => '/ko/path/index.html',
+            'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co',
+            'HTTP_X_FORWARDED_REQUEST_URI' => '/sv/path/index.html'
+        );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
         $pathlang = $headers->computePathLang();
         $this->assertEquals('en', $pathlang);
     }
 
-    public function testPathLangWithUseProxyFalse()
+    public function testPathLangWithPathAndUseProxyTrue()
+    {
+        $settings = array(
+            'url_pattern_name' => 'path',
+            'use_proxy' => 1
+        );
+        $env = array(
+            'SERVER_NAME' => 'ja.wovn.io',
+            'REQUEST_URI' => '/ko/path/index.html',
+            'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co',
+            'HTTP_X_FORWARDED_REQUEST_URI' => '/sv/path/index.html'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $pathlang = $headers->computePathLang();
+        $this->assertEquals('sv', $pathlang);
+    }
+
+    public function testPathLangWithSubdomainAndUseProxyFalse()
     {
         $settings = array(
             'url_pattern_name' => 'subdomain',
@@ -763,12 +786,32 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         );
         $env = array(
             'SERVER_NAME' => 'ja.wovn.io',
-            'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co'
+            'REQUEST_URI' => '/ko/path/index.html',
+            'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co',
+            'HTTP_X_FORWARDED_REQUEST_URI' => '/sv/path/index.html'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
         $pathlang = $headers->computePathLang();
         $this->assertEquals('ja', $pathlang);
+    }
+
+    public function testPathLangWithPathAndUseProxyFalse()
+    {
+        $settings = array(
+            'url_pattern_name' => 'path',
+            'use_proxy' => false
+        );
+        $env = array(
+            'SERVER_NAME' => 'ja.wovn.io',
+            'REQUEST_URI' => '/ko/path/index.html',
+            'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co',
+            'HTTP_X_FORWARDED_REQUEST_URI' => '/sv/path/index.html'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $pathlang = $headers->computePathLang();
+        $this->assertEquals('ko', $pathlang);
     }
 
     public function testPathLangWithUseProxyTrueButNoForwardedHost()

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -1346,7 +1346,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/path', $headers->getDocumentURI());
     }
 
-    public function testUrlKeepTrailingSlash__NoProxy()
+    public function testUrlKeepTrailingSlashWithoutProxy()
     {
         $settings = array(
             'url_pattern_name' => 'path',
@@ -1363,7 +1363,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://sub.domain.com/path', $headers->urlKeepTrailingSlash);
     }
 
-    public function testUrlKeepTrailingSlash__UseProxy()
+    public function testUrlKeepTrailingSlashWithUseProxy()
     {
         $settings = array(
             'url_pattern_name' => 'path',


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
When WOVN.php serves a request behind a proxy and the request URI gets modified in the process, it will need to read the original request URI from a HTTP Header. The header name for original URI is `X-Forwarded-Request-Uri`, and it must be manually set by the user. See the README for an example of how set it.

The original client requested URI is needed in order to correctly identify the requested page, and is used for setting hreflang tags in the HTML content and for locating the correct translation data.

WOVN.php will only look at the `X-Forwarded-Request-Uri` header if `use_proxy = 1` is set in wovn.ini.