### PR TITLE
Support Custom Lang Aliases in `supported_langs`

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,5 +3,5 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    define('WOVN_PHP_VERSION', '0.1.11');
+    define('WOVN_PHP_VERSION', '0.1.12');
 }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -96,7 +96,7 @@ class Store
      * @param array $updatedOptions The options to update in the settings
      * @return array The new settings of the user
      */
-    public function updateSettings($updatedOptions)
+    private function updateSettings($updatedOptions)
     {
         $defaultSettings = $this->defaultSettings();
 

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -103,6 +103,7 @@ class Store
             'save_memory_by_sending_wovn_ignore_content' => false
         );
     }
+
     /**
      * Updates the current settings of the user in the class \n
      *
@@ -148,6 +149,10 @@ class Store
 
         if (isset($vals['custom_lang_aliases']) && !is_array($vals['custom_lang_aliases'])) {
             $vals['custom_lang_aliases'] = array();
+        } else {
+            if (isset($vals['custom_lang_aliases']) && isset($vals['supported_langs'])) {
+                $vals['supported_langs'] = $this->ensureValidSupportedLanguages($vals['supported_langs'], $vals['custom_lang_aliases']);
+            }
         }
 
         if (isset($vals['ignore_paths']) && !is_array($vals['ignore_paths'])) {
@@ -166,6 +171,17 @@ class Store
         $this->configLoaded = true;
 
         return $vals;
+    }
+
+    private function ensureValidSupportedLanguages($supportedLangs, $customLangAliases)
+    {
+        if (isset($supportedLangs)) {
+            foreach ($supportedLangs as $index => $langCode) {
+                $supportedLangs[$index] = $this->convertToOriginalCode($langCode, $customLangAliases);
+            }
+        }
+
+        return $supportedLangs;
     }
 
     private function isWovnDevModeActivated($settings = null)
@@ -204,9 +220,13 @@ class Store
         return $lang_code;
     }
 
-    public function convertToOriginalCode($lang_code)
+    public function convertToOriginalCode($lang_code, $customLangAliases = null)
     {
-        foreach ($this->settings['custom_lang_aliases'] as $lang => $custom_lang) {
+        if ($customLangAliases == null) {
+            $customLangAliases = $this->settings['custom_lang_aliases'];
+        }
+
+        foreach ($customLangAliases as $lang => $custom_lang) {
             if ($lang_code == $custom_lang) {
                 return $lang;
             }

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -275,4 +275,20 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         unlink($file_config);
         $this->assertEquals('ja-test', $store->convertToCustomLangCode('ja'));
     }
+
+    public function testFixSupportedLangsSetWithCustomLangCode()
+    {
+        $sut = new Store(array(
+            'project_token' => 'T0k3n_',
+            'default_lang' => 'en',
+            'supported_langs' => array('en', 'fr', 'cn', 'tw', 'kr'),
+            'custom_lang_aliases' => array(
+                'zh-CHS' => 'cn',
+                'zh-CHT' => 'tw',
+                'ko' => 'kr'
+            )
+        ));
+
+        $this->assertEquals(array('en', 'fr', 'zh-CHS', 'zh-CHT', 'ko'), $sut->settings['supported_langs']);
+    }
 }


### PR DESCRIPTION
### Purpose/goal of PR
Support users that use custom lang aliases in their list of supported languages.

### Comments
Some user mistake and input their custom language codes in the list of supported languages. This leads to invalid hreflangs being generated by WOVN.php. This change iterates through supported languages list and ensure the language codes are set to valid WOVN.php language codes, using user's custom lang aliases if necessary.