### PR TITLE
[MISC]Add test target php versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,14 @@ jobs:
       - run: scripts/run_phpunit_tests.sh php:5.6-apache
       - run: scripts/run_phpunit_tests.sh vectorface/hhvm
       - run: scripts/run_phpunit_tests.sh php:7.0-apache
+      - run: scripts/run_phpunit_tests.sh php:7.1-apache
+      - run: scripts/run_phpunit_tests.sh php:7.2-apache
       - run: scripts/run_phpunit_tests.sh php:7.3-apache
       - run: scripts/run_server_tests.sh php:5.3-apache
       - run: scripts/run_server_tests.sh php:5.4-apache
       - run: scripts/run_server_tests.sh php:5.5-apache
       - run: scripts/run_server_tests.sh php:5.6-apache
       - run: scripts/run_server_tests.sh php:7.0-apache
+      - run: scripts/run_server_tests.sh php:7.1-apache
+      - run: scripts/run_server_tests.sh php:7.2-apache
       - run: scripts/run_server_tests.sh php:7.3-apache


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
I added test target php versions using docker image similar to WOVN.php.
Wordpress plugin supports php 5.3 or higher.

### Comments

### Release comments (new feature)
