### PR TITLE
Prevent Interception Errors Due to CWD Changed

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,5 +3,5 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    define('WOVN_PHP_VERSION', '0.1.16');
+    define('WOVN_PHP_VERSION', '0.1.17');
 }

--- a/src/wovn_helper.php
+++ b/src/wovn_helper.php
@@ -87,6 +87,7 @@ function wovn_helper_include_by_paths($paths)
 {
     foreach ($paths as $path) {
         if (is_file($path)) {
+            chdir(dirname($path));
             include($path);
             return true;
         }


### PR DESCRIPTION
### Purpose/goal of PR
Prevent interception errors due to CWD changed

### Comments
When WOVN.php intercepts through wovn_index.php, CWD is the root because wovn_index.php is at the root. However, the file intercepted by WOVN.php is not necessary at the root and relative imports become broken. This PR set the CWD to the directory of the file intercepted.