### PR TITLE
Restrict ignore paths matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,24 @@ query[] = forgot_password
 #### `ignore_paths`
 This parameter tells WOVN.php to not localize content withing given directories.
 
-For instance, if you want to not localize the admin panels of your website, you
-should configure WOVN.php as below. WOVN.php will localize
-`https://my-website.com/index.html` but not `https://my-wesite.com/admin/` nor
-`https://my-website.com/admin/plugin.html`.
-```
+The directories given will only be matched against the beginning of the URL path.
+
+For instance, if you want to not localize the `admin` directory of your website, you
+should configure WOVN.php as below.
+```Text
 ignore_paths[] = /admin
+```
+With this configuration, WOVN.php will ignore the following URLs
+```Text
+https://my-wesite.com/admin
+https://my-wesite.com/admin/
+https://my-website.com/admin/plugin.html
+```
+but allow the following
+```Text
+https://my-website.com/index.html
+https://my-website.com/user/admin
+https://my-website.com/adminpage
 ```
 
 #### `ignore_regex`

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ WOVN.php as below. WOVN.php will localize
 `https://my-website.com/search/index.php` but not
 `https://my-website.com/search/01/` nor `https://my-website.com/search/02/`.
 ```
-ignore_paths[] = /\/search\/\d\d\//
+ignore_regex[] = /\/search\/\d\d\//
 ```
 
 #### `ignore_class`

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -21,7 +21,8 @@ list($store, $headers) = Utils::getStoreAndHeaders($_SERVER);
 $_ENV['WOVN_TARGET_LANG'] = $headers->lang();
 $headers->requestOut();
 
-if (!Utils::isFilePathURI($headers->getDocumentURI(), $store)) {
+if (!Utils::isFilePathURI($headers->getDocumentURI(), $store) &&
+    !Utils::isIgnoredPath($headers->getDocumentURI(), $store)) {
     // use the callback of ob_start to modify the content and return
     ob_start(function ($buffer) use ($headers, $store) {
         $headers->responseOut();

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -44,7 +44,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.jpg', $store));
     }
 
-    public function testIsIgnoredPath__usingIgnorePathSetting()
+    public function testIsIgnoredPathUsingIgnorePathSetting()
     {
         $env = EnvFactory::fromFixture('default');
         list($store, $headers) = Utils::getStoreAndHeaders($env);
@@ -73,7 +73,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, Utils::isIgnoredPath('https://google.com/user/admin', $store));
     }
 
-    public function testIsIgnoredPath__usingIgnoreRegexSetting()
+    public function testIsIgnoredPathUsingIgnoreRegexSetting()
     {
         $env = EnvFactory::fromFixture('default');
         list($store, $headers) = Utils::getStoreAndHeaders($env);

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -54,6 +54,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/assets/img/boop', $store));
         $this->assertEquals(true, Utils::isFilePathURI('https://google.com/img/assets', $store));
         $this->assertEquals(false, Utils::isFilePathURI('https://google.com/img/assets/index.html', $store));
+        $this->assertEquals(false, Utils::isFilePathURI('https://google.com/img/coucou.jpg', $store));
     }
 
     public function testIsHtml()


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
Change `ignore_paths` setting to only match against URLs from the beginning of the path.

### Comments
Leading and trailing slash in `ignore_paths` values are effectively ignored, and the values are interpreted as if starting with a leading slash and ending with no trailing slash.
Therefore, the following four values will have the exact same result
```
global
/global
global/
/global/
```

The values above will match URLs of the following form
```
example.com/global
example.com/global/
example.com/global/images/dog.png
```

And not match URLs like
```
example.com/events/global
example.com/globalized
```