### PR TITLE
Add noindex for specified languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ ignore_class[] = ignore
 ignore_class[] = no-translate
 ```
 
+#### `no_index_langs`
+This parameter tells WOVN.php which languages's HTML should be set `noindex` 
+to avoid index by web crawler.
+
+For instance, if you want to avoid index for English pages, add `en` as below. 
+`<meta name="robots" content="noindex">` tag will be inserted inside `head` tag 
+for English pages.
+```
+no_index_langs[] = en
+```
+
 #### `encoding`
 This parameter tells WOVN.php which encoding you use for you files. WOVN.php
 supports 8 encodings: `UTF-8`, `EUC-JP`, `SJIS`, `eucJP-win`, `SJIS-win`, `JIS`,

--- a/htaccess_sample
+++ b/htaccess_sample
@@ -1,5 +1,7 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
+  # For path pattern, remove language code
+  # RewriteRule ^/?(?:ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi)($|/.*$) $1 [L]
 
   # Don't intercept .cgi files, as they won't execute
   RewriteCond %{THE_REQUEST} \.cgi

--- a/src/version.php
+++ b/src/version.php
@@ -3,5 +3,5 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    define('WOVN_PHP_VERSION', '0.1.17');
+    define('WOVN_PHP_VERSION', '0.1.18');
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -228,7 +228,9 @@ class HtmlConverter
 
         $hreflangTags = array();
         foreach ($lang_codes as $lang_code) {
-            if ($this->isNoindexLang($lang_code)) continue;
+            if ($this->isNoindexLang($lang_code)) {
+                continue;
+            }
             $href = $this->buildHrefLang($lang_code);
             array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso6391Normalization($lang_code) . '" href="' . $href . '">');
         }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -44,6 +44,11 @@ class HtmlConverter
     {
         $this->html = $this->insertSnippet($this->html, $adds_backend_error_mark);
         $this->html = $this->insertHreflangTags($this->html);
+
+        if ($this->isNoindexLang($this->headers->lang())) {
+            $this->html = $this->insertNoindex($this->html);
+        }
+
         $marker = new HtmlReplaceMarker();
         return array($this->html, $marker);
     }
@@ -148,6 +153,18 @@ class HtmlConverter
         return $this->insertAfterTag($parent_tags, $html, $snippet_code);
     }
 
+    private function insertNoindex($html)
+    {
+        $noindexMetaTag = '<meta name="robots" content="noindex">';
+        $parent_tags = array("(<head\s?.*?>)");
+        return $this->insertAfterTag($parent_tags, $html, $noindexMetaTag);
+    }
+
+    private function isNoindexLang($lang)
+    {
+        return in_array($lang, $this->store->settings['no_index_langs']);
+    }
+
     private function insertAfterTag($tag_names, $html, $insert_str)
     {
         foreach ($tag_names as $tag_name) {
@@ -211,6 +228,7 @@ class HtmlConverter
 
         $hreflangTags = array();
         foreach ($lang_codes as $lang_code) {
+            if ($this->isNoindexLang($lang_code)) continue;
             $href = $this->buildHrefLang($lang_code);
             array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso6391Normalization($lang_code) . '" href="' . $href . '">');
         }

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -55,6 +55,9 @@ class API
         if (count($store->settings['custom_lang_aliases']) > 0) {
             $data['custom_lang_aliases'] = json_encode($store->settings['custom_lang_aliases']);
         }
+        if (count($store->settings['no_index_langs']) > 0) {
+            $data['no_index_langs'] = json_encode($store->settings['no_index_langs']);
+        }
 
         try {
             $request_handler = RequestHandlerFactory::getBestAvailableRequestHandler();

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -78,6 +78,7 @@ class Store
             'ignore_paths' => array(),
             'ignore_regex' => array(),
             'ignore_class' => array(),
+            'no_index_langs' => array(),
 
             // Set to true to check if intercepted file is an AMP file.
             // Because WOVN.php interception is explicit, in most cases AMP files
@@ -136,6 +137,9 @@ class Store
             if (isset($this->settings['supported_langs'])) {
                 $this->ensureValidSupportedLanguages();
             }
+            if (isset($this->settings['no_index_langs'])) {
+                $this->ensureValidNoIndexLangs();
+            }
         }
 
         if (!is_array($this->settings['ignore_paths'])) {
@@ -170,6 +174,13 @@ class Store
     {
         foreach ($this->settings['supported_langs'] as $index => $langCode) {
             $this->settings['supported_langs'][$index] = $this->convertToOriginalCode($langCode);
+        }
+    }
+
+    private function ensureValidNoIndexLangs()
+    {
+        foreach ($this->settings['no_index_langs'] as $index => $langCode) {
+            $this->settings['no_index_langs'][$index] = $this->convertToOriginalCode($langCode);
         }
     }
 

--- a/test/fixtures/basic_html/insert_hreflang_expected_multi_noindex_langs.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_multi_noindex_langs.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta name="robots" content="noindex"><link rel="alternate" hreflang="zh-Hant" href="http://my-site.com/ct/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;langParamName=wovn&amp;version=WOVN.php" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected_noindex_langs.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_noindex_langs.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta name="robots" content="noindex"><link rel="alternate" hreflang="zh-Hant" href="http://my-site.com/ct/"><link rel="alternate" hreflang="zh-Hans" href="http://my-site.com/cs/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;langParamName=wovn&amp;version=WOVN.php" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -137,6 +137,25 @@ class APITest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected_result, $result);
     }
 
+    public function testTranslateWithNoindexLangs()
+    {
+        $settings = array('no_index_langs' => array('en'));
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $html = '<html><head></head><body><h1>en</h1></body></html>';
+        $response = '{"body":"\u003Chtml\u003E\u003Chead\u003E\u003C/head\u003E\u003Cbody\u003E\u003Ch1\u003Efr\u003C/h1\u003E\u003C/body\u003E\u003C/html\u003E"}';
+
+        $expected_api_url = $this->getExpectedApiUrl($store, $headers, $html);
+        $expected_head_content = $this->getExpectedHtmlHeadContent($store, $headers);
+        $expected_html = "<html><head>$expected_head_content</head><body><h1>en</h1></body></html>";
+        $expected_data = $this->getExpectedData($store, $headers, $expected_html, array('no_index_langs' => json_encode(array('en'))));
+        $expected_result = '<html><head></head><body><h1>fr</h1></body></html>';
+
+        $this->mockApiResponse($expected_api_url, $expected_data, $response);
+
+        $result = API::translate($store, $headers, $html);
+        $this->assertEquals($expected_result, $result);
+    }
+
     public function testTranslateWithCustomLangAliases()
     {
         $settings = array('custom_lang_aliases' => array('ja' => 'ja-test'));

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -228,24 +228,6 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://wovn.global.ssl.fastly.net/v0/', $store->settings['api_url']);
     }
 
-    public function testConvertToNoIndexLangs()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode( "\n", array(
-            'project_token = "T0k3N"',
-            'default_lang = "English"',
-            'no_index_langs[] = en',
-            'no_index_langs[] = fr'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
-    }
-
     public function testCustomApiUrlSettingNotChangedWithWovnDevModeOn()
     {
         $file_config = dirname(__FILE__) . '/test_config.ini';
@@ -308,5 +290,23 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals(array('en', 'fr', 'zh-CHS', 'zh-CHT', 'ko'), $sut->settings['supported_langs']);
+    }
+
+    public function testNoIndexLangs()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode("\n", array(
+            'project_token = "T0k3N"',
+            'default_lang = "English"',
+            'no_index_langs[] = en',
+            'no_index_langs[] = fr'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
     }
 }

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -228,6 +228,24 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://wovn.global.ssl.fastly.net/v0/', $store->settings['api_url']);
     }
 
+    public function testConvertToNoIndexLangs()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode( "\n", array(
+            'project_token = "T0k3N"',
+            'default_lang = "English"',
+            'no_index_langs[] = en',
+            'no_index_langs[] = fr'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
+    }
+
     public function testCustomApiUrlSettingNotChangedWithWovnDevModeOn()
     {
         $file_config = dirname(__FILE__) . '/test_config.ini';

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -746,6 +746,48 @@ bye
         $this->assertEquals($expected_html_text, $translated_html);
     }
 
+    public function testInsertHreflangWithNoindexLangs()
+    {
+        libxml_use_internal_errors(true);
+        $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+        $settings = array(
+            'default_lang' => 'en',
+            'supported_langs' => array('en', 'zh-CHT', 'zh-CHS'),
+            'custom_lang_aliases' => array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct'),
+            'url_pattern_name' => 'path',
+            'lang_param_name' => 'wovn',
+            'no_index_langs' => array('en')
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+        $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_noindex_langs.html');
+
+        $this->assertEquals($expected_html_text, $translated_html);
+    }
+
+    public function testInsertHreflangWithMultiNoindexLangs()
+    {
+        libxml_use_internal_errors(true);
+        $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+        $settings = array(
+            'default_lang' => 'en',
+            'supported_langs' => array('en', 'zh-CHT', 'zh-CHS'),
+            'custom_lang_aliases' => array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct'),
+            'url_pattern_name' => 'path',
+            'lang_param_name' => 'wovn',
+            'no_index_langs' => array('en', 'cs', 'fr')
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+        $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_multi_noindex_langs.html');
+
+        $this->assertEquals($expected_html_text, $translated_html);
+    }
+
     private function executeConvert($converter, $html, $charset, $name)
     {
         $dom = SimpleHtmlDom::str_get_html($html, $charset, false, false, $charset, false);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/IS-711

I added `no_index_langs` and you can set it in `wovn.ini` as below.
`no_index_langs` can be set with custom_lang_aliases lang.
```
no_index_langs[] = en
```

if `no_index_langs` include `en`, WOVN.php will behave like the followings.
- Add `<meta name="robots" content="noindex">` for English pages
- Don't add hreflang for English for all pages
- Add `no_index_langs` param for request to html-swapper

### Comments

### Release comments (new feature)
