### PR TITLE
[Hotfix] Change env variable name for WOVN_CONFIG

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -441,9 +441,9 @@ This environment variable allows the user to change the default `wovn.ini` path 
 an arbitrary configuration file path.
 For example, you can make changes as follows
 
-Users can set `$_ENV['WOVN_CONFIG']` before loading `wovn_interceptor.php`.
+Users can set `$_SERVER['WOVN_CONFIG']` before loading `wovn_interceptor.php`.
 ```
-$_ENV['WOVN_CONFIG'] = ... your config path ...;
+$_SERVER['WOVN_CONFIG'] = ... your config path ...;
 
 require_once('/path/to/WOVN.php/src/wovn_interceptor.php');
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -463,9 +463,9 @@ if ($_ENV['WOVN_TARGET_LANG'] == 'fr') {
 この環境変数は、ユーザがデフォルトの `wovn.ini` のパスを任意の設定ファイルのパスに変更することを可能にします。  
 例えば、以下のように変更することができます。
 
-ユーザは `wovn_interceptor.php` を読み込む前に `$_ENV['WOVN_CONFIG']` を設定することができます。
+ユーザは `wovn_interceptor.php` を読み込む前に `$_SERVER['WOVN_CONFIG']` を設定することができます。
 ```
-$_ENV['WOVN_CONFIG'] = ... your config path ...;
+$_SERVER['WOVN_CONFIG'] = ... your config path ...;
 
 require_once('/path/to/WOVN.php/src/wovn_interceptor.php');
 ```

--- a/src/version.php
+++ b/src/version.php
@@ -3,5 +3,5 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    define('WOVN_PHP_VERSION', '0.1.22');
+    define('WOVN_PHP_VERSION', '0.1.23');
 }

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -11,7 +11,7 @@ class Utils
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)
     {
-        $file = isset($_ENV['WOVN_CONFIG']) ? $_ENV['WOVN_CONFIG'] : DIRNAME(__FILE__) . '/../../../../wovn.ini';
+        $file = isset($env['WOVN_CONFIG']) ? $env['WOVN_CONFIG'] : DIRNAME(__FILE__) . '/../../../../wovn.ini';
         $store = Store::createFromFile($file);
         $headers = new Headers($env, $store);
         return array($store, $headers);

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -29,17 +29,16 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 
     public function testGetStoreAndHeadersWithWovnConfigOfEnv()
     {
-        $_ENV['WOVN_CONFIG'] = dirname(__FILE__) . '/../fixtures/config/siteA.ini';
         $env = EnvFactory::fromFixture('default');
+        $env['WOVN_CONFIG'] = dirname(__FILE__) . '/../fixtures/config/siteA.ini';
         list($store, $headers) = Utils::getStoreAndHeaders($env);
         $this->assertEquals('SiteA', $store->settings['project_token']);
 
-        $_ENV['WOVN_CONFIG'] = dirname(__FILE__) . '/../fixtures/config/siteB.ini';
         $env = EnvFactory::fromFixture('default');
+        $env['WOVN_CONFIG'] = dirname(__FILE__) . '/../fixtures/config/siteB.ini';
         list($store, $headers) = Utils::getStoreAndHeaders($env);
         $this->assertEquals('SiteB', $store->settings['project_token']);
 
-        unset($_ENV['WOVN_CONFIG']);
         $env = EnvFactory::fromFixture('default');
         list($store, $headers) = Utils::getStoreAndHeaders($env);
         $this->assertEquals('', $store->settings['project_token']);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
When I do a `SetEnv` in `.htaccess`, it means `$_SERVER['WOVN_CONFIG']`.
Therefore, change from `$_ENV` to `$_SERVER`.

### Comments
After this, I'll try to add some additional integration tests include `.htaccess`.

### Release comments (new feature)
