### PR TITLE
Translate redirects on non-apache webservers.

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.1.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.1.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.0.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.0.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -337,26 +337,12 @@ class Headers
      */
     public function responseOut()
     {
-        function get_response_headers () {
-            if (function_exists('apache_response_headers')) {
-                return apache_response_headers();
-            }
-
-            $result = array();
-            $headers = headers_list();
-            foreach ($headers as $header) {
-                $header = explode(":", $header);
-                $result[array_shift($header)] = trim(implode(":", $header));
-            }
-            return $result;
-        }
-
         $lang = $this->computePathLang();
 
         if ($lang && strlen($lang) > 0) {
             if (!headers_sent()) {
                 $locationHeaders = array('location', 'Location');
-                $responseHeaders = get_response_headers();
+                $responseHeaders = $this->getResponseHeaders();
 
                 foreach ($locationHeaders as $locationHeader) {
                     if (array_key_exists($locationHeader, $responseHeaders)) {
@@ -368,6 +354,20 @@ class Headers
                 }
             }
         }
+    }
+
+    private function getResponseHeaders () {
+        if (function_exists('apache_response_headers')) {
+            return apache_response_headers();
+        }
+
+        $result = array();
+        $headers = headers_list();
+        foreach ($headers as $header) {
+            $header = explode(":", $header);
+            $result[array_shift($header)] = trim(implode(":", $header));
+        }
+        return $result;
     }
 
     /**

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -356,7 +356,8 @@ class Headers
         }
     }
 
-    private function getResponseHeaders() {
+    private function getResponseHeaders()
+    {
         if (function_exists('apache_response_headers')) {
             return apache_response_headers();
         }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -337,12 +337,26 @@ class Headers
      */
     public function responseOut()
     {
+        function get_response_headers () {
+            if (function_exists('apache_response_headers')) {
+                return apache_response_headers();
+            }
+
+            $arh = array();
+            $headers = headers_list();
+            foreach ($headers as $header) {
+                $header = explode(":", $header);
+                $arh[array_shift($header)] = trim(implode(":", $header));
+            }
+            return $arh;
+        }
+
         $lang = $this->computePathLang();
 
         if ($lang && strlen($lang) > 0) {
-            if (function_exists('apache_response_headers') && !headers_sent()) {
+            if (!headers_sent()) {
                 $locationHeaders = array('location', 'Location');
-                $responseHeaders = apache_response_headers();
+                $responseHeaders = get_response_headers();
 
                 foreach ($locationHeaders as $locationHeader) {
                     if (array_key_exists($locationHeader, $responseHeaders)) {

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -342,13 +342,13 @@ class Headers
                 return apache_response_headers();
             }
 
-            $arh = array();
+            $result = array();
             $headers = headers_list();
             foreach ($headers as $header) {
                 $header = explode(":", $header);
-                $arh[array_shift($header)] = trim(implode(":", $header));
+                $result[array_shift($header)] = trim(implode(":", $header));
             }
-            return $arh;
+            return $result;
         }
 
         $lang = $this->computePathLang();

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -356,7 +356,7 @@ class Headers
         }
     }
 
-    private function getResponseHeaders () {
+    private function getResponseHeaders() {
         if (function_exists('apache_response_headers')) {
             return apache_response_headers();
         }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/SUP-246
### Comments
`apache_response_headers` obviously only exists on Apache servers.
Redirects to `/dir/page` etc need to be translated to `/en/dir/page` by WOVN.php
### Release comments (new feature)
