### PR TITLE
Changed to rely on content-type/mime-type to determine if the buffer …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
   "description": "PHP server library for WOVNio",
   "homepage": "https://wovn.io",
   "require": {
-    "php": ">=5.3"
+    "php": ">=5.3",
+    "ext-fileinfo": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.3.*",

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -34,12 +34,6 @@ $headers->requestOut();
 
 $uri = $headers->getDocumentURI();
 if (!Utils::isIgnoredPath($uri, $store)) {
-    $filePath = wovn_helper_detect_paths(__DIR__ . '/../..', $uri);
-    $mimeType = false;
-    if (!empty($filePath)) {
-        $mimeType = mime_content_type($filePath[0]);
-    }
-
     $diagnostics = null;
     $benchmarkStart = 0;
     if (Utils::wovnDiagnosticsEnabled($store, $headers)) {
@@ -48,11 +42,11 @@ if (!Utils::isIgnoredPath($uri, $store)) {
         $diagnostics = new Diagnostics($store);
     }
     // use the callback of ob_start to modify the content and return
-    ob_start(function ($buffer) use ($headers, $store, $diagnostics, $benchmarkStart, $mimeType) {
+    ob_start(function ($buffer) use ($headers, $store, $diagnostics, $benchmarkStart) {
 
         $headers->responseOut();
 
-        if (empty($buffer) || !Utils::isHtml($mimeType, $buffer)) {
+        if (empty($buffer) || !Utils::isHtml($buffer)) {
             return $buffer;
         }
 

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -36,12 +36,7 @@ class Utils
     public static function isHtml($contentType, $buffer)
     {
         if ($contentType) {
-            if (preg_match('/html/', strtolower($contentType))) {
-                return true;
-            } else {
-                // fallback check
-                return $buffer != strip_tags($buffer);
-            }
+            return preg_match('/html|php/', strtolower($contentType));
         }
         return $buffer != strip_tags($buffer);
     }

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -39,11 +39,10 @@ class Utils
             if (preg_match('/html/', strtolower($contentType))) {
                 return true;
             } else {
-                return false;
+                // fallback check
+                return $buffer != strip_tags($buffer);
             }
         }
-
-        // fallback check
         return $buffer != strip_tags($buffer);
     }
 

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -1,6 +1,8 @@
 <?php
 namespace Wovnio\Wovnphp;
 
+use finfo;
+
 class Utils
 {
     // will return the store and headers objects
@@ -33,10 +35,19 @@ class Utils
         }
     }
 
-    public static function isHtml($contentType, $buffer)
+    public static function isHtml($buffer)
     {
+        $finfo = new finfo(FILEINFO_MIME);
+        $contentType = $finfo->buffer($buffer);
+
         if ($contentType) {
-            return preg_match('/html|php/', strtolower($contentType));
+            if (preg_match('/html|php/', strtolower($contentType))) {
+                return true;
+            } elseif (preg_match('/text/', strtolower($contentType))) {
+                return $buffer != strip_tags($buffer);
+            } else {
+                return false;
+            }
         }
         return $buffer != strip_tags($buffer);
     }

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -3,11 +3,6 @@ namespace Wovnio\Wovnphp;
 
 class Utils
 {
-    const IMAGE_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((?!jp$)jpe?g?|bmp|gif|png|btif|tiff?|psd|djvu?|xif|wbmp|webp|p(n|b|g|p)m|rgb|tga|x(b|p)m|xwd|pic|ico|fh(c|4|5|7)?|xif|f(bs|px|st)))/i";
-    const AUDIO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(mp(3|2)|m(p?2|3|p?4|pg)a|midi?|kar|rmi|web(m|a)|aif(f?|c)|w(ma|av|ax)|m(ka|3u)|sil|s3m|og(a|g)|uvv?a))/i";
-    const VIDEO_FILE_PATTERN = "/^(https?:\/\/)?.*(\.(m(x|4)u|fl(i|v)|3g(p|2)|jp(gv|g?m)|mp(4v?|g4|e?g)|m(1|2)v|ogv|m(ov|ng)|qt|uvv?(h|m|p|s|v)|dvb|mk(v|3d|s)|f4v|as(x|f)|w(m(v|x)|vx)))/i";
-    const DOC_FILE_PATTERN = "/^(https?:\/\/)?.*(\.((7|g)?zip|tar|rar|7z|gz|ez|aw|atom(cat|svc)?|(cc)?xa?ml|cdmi(a|c|d|o|q)?|epub|g(ml|px|xf)|jar|js|ser|class|json(ml)?|do(c|t)(m|x)?|xls(m|x)?|xps|pp(a|tx?|s)m?|potm?|sldm|mp(p|t)|bin|dms|lrf|mar|so|dist|distz|m?pkg|bpk|dump|rtf|tfi|pdf|pgp|apk|o(t|d)(b|c|ft?|g|h|i|p|s|t)))/i";
-
     // will return the store and headers objects
     public static function getStoreAndHeaders(&$env)
     {
@@ -38,22 +33,15 @@ class Utils
         }
     }
 
-    public static function isHtml($response_headers, $buffer)
+    public static function isHtml($contentType, $buffer)
     {
-        // Because Apache sets header automatically when Content-Type is not set,
-        // check the header only when it exists.
-        foreach ($response_headers as $response_header) {
-            $header_data = explode(':', $response_header);
-            if (count($header_data) < 2) {
-                continue;
-            }
-            if (strtolower(trim($header_data[0])) == 'content-type') {
-                if (!preg_match('/html/', $header_data[1])) {
-                    return false;
-                }
+        if ($contentType) {
+            if (!preg_match('/html/', strtolower($contentType))) {
+                return false;
             }
         }
 
+        // fallback check
         return $buffer != strip_tags($buffer);
     }
 
@@ -71,26 +59,6 @@ class Utils
         }
 
         return false;
-    }
-
-    /*
-     * Return true if $uri is an image, audio, video, or some doc filepath.
-     * Return false otherwise.
-     */
-    public static function isFilePathURI($uri, $store)
-    {
-        if (!$uri) {
-            return false;
-        }
-
-        $uri = self::removeQueryAndHash($uri);
-
-        return (
-            preg_match(self::IMAGE_FILE_PATTERN, $uri) ||
-            preg_match(self::AUDIO_FILE_PATTERN, $uri) ||
-            preg_match(self::VIDEO_FILE_PATTERN, $uri) ||
-            preg_match(self::DOC_FILE_PATTERN, $uri)
-        );
     }
 
     /*

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -36,7 +36,9 @@ class Utils
     public static function isHtml($contentType, $buffer)
     {
         if ($contentType) {
-            if (!preg_match('/html/', strtolower($contentType))) {
+            if (preg_match('/html/', strtolower($contentType))) {
+                return true;
+            } else {
                 return false;
             }
         }

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -98,16 +98,11 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 
     public function testIsHtml()
     {
-        $this->assertEquals(false, Utils::isHtml(false, 'this is not html, even tho it contains < and >'));
+        $this->assertEquals(false, Utils::isHtml('this is not html, even tho it contains < and >'));
 
-        $this->assertEquals(true, Utils::isHtml(false, '<html><head></head><body><p>this is html</p></body></html>'));
-        $this->assertEquals(true, Utils::isHtml(false, '<p>this is html</p>'));
-
-        $this->assertEquals(true, Utils::isHtml('text/html', '<p>this is html</p>'));
-        $this->assertEquals(true, Utils::isHtml('Text/Html', '<p>this is html</p>'));
-        $this->assertEquals(true, Utils::isHtml('application/xhtml+xml', '<p>this is xhtml</p>'));
-        $this->assertEquals(false, Utils::isHtml('application/json', '<p>this is json</p>'));
-        $this->assertEquals(false, Utils::isHtml('application/pdf', '<p>this is pdf</p>'));
+        $this->assertEquals(true, Utils::isHtml('<html><head></head><body><p>this is html</p></body></html>'));
+        $this->assertEquals(true, Utils::isHtml('<?php require_once(\'{$this->docRoot}/WOVN.php/src/wovn_interceptor.php\'); ?><html><head></head><body>test</body></html>'));
+        $this->assertEquals(false, Utils::isHtml('this is json'));
     }
 
     public function testIsAmp()

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -45,32 +45,6 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $store->settings['project_token']);
     }
 
-    public function testIsFilePathURI()
-    {
-        $env = EnvFactory::fromFixture('default');
-        list($store, $headers) = Utils::getStoreAndHeaders($env);
-
-        $this->assertEquals(false, Utils::isFilePathURI('https://google.com', $store));
-        $this->assertEquals(false, Utils::isFilePathURI('https://google.com/mp3', $store));
-        $this->assertEquals(false, Utils::isFilePathURI('https://google.com/#mp3', $store));
-        $this->assertEquals(false, Utils::isFilePathURI('https://google.com/?mp3', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('/test.mp3', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('/lvl1/lvl2/file.pdf', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.zip', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.7zip', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.7z', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.gzip', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.rar', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.tar.gz', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.jpg', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.pdf', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.doc', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.docx', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.xls', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.xlsx', $store));
-        $this->assertEquals(true, Utils::isFilePathURI('https://google.com/coucou.xlsm', $store));
-    }
-
     public function testIsIgnoredPathUsingIgnorePathSetting()
     {
         $env = EnvFactory::fromFixture('default');
@@ -124,15 +98,16 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 
     public function testIsHtml()
     {
-        $this->assertEquals(false, Utils::isHtml(array(), 'this is not html, even tho it contains < and >'));
+        $this->assertEquals(false, Utils::isHtml(false, 'this is not html, even tho it contains < and >'));
 
-        $this->assertEquals(true, Utils::isHtml(array(), '<html><head></head><body><p>this is html</p></body></html>'));
-        $this->assertEquals(true, Utils::isHtml(array(), '<p>this is html</p>'));
+        $this->assertEquals(true, Utils::isHtml(false, '<html><head></head><body><p>this is html</p></body></html>'));
+        $this->assertEquals(true, Utils::isHtml(false, '<p>this is html</p>'));
 
-        $this->assertEquals(true, Utils::isHtml(array('Content-Type: text/html'), '<p>this is html</p>'));
-        $this->assertEquals(true, Utils::isHtml(array('Content-Type: application/xhtml+xml'), '<p>this is xhtml</p>'));
-        $this->assertEquals(false, Utils::isHtml(array('Content-Type: application/json'), '<p>this is json</p>'));
-        $this->assertEquals(false, Utils::isHtml(array('Content-Type: application/pdf'), '<p>this is pdf</p>'));
+        $this->assertEquals(true, Utils::isHtml('text/html', '<p>this is html</p>'));
+        $this->assertEquals(true, Utils::isHtml('Text/Html', '<p>this is html</p>'));
+        $this->assertEquals(true, Utils::isHtml('application/xhtml+xml', '<p>this is xhtml</p>'));
+        $this->assertEquals(false, Utils::isHtml('application/json', '<p>this is json</p>'));
+        $this->assertEquals(false, Utils::isHtml('application/pdf', '<p>this is pdf</p>'));
     }
 
     public function testIsAmp()


### PR DESCRIPTION
…should be translated.

### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-324

### Comments
The general idea is that we can use the mime-type of a file to determine if it should be translated (html etc) or not, instead of relying on looking at the request URI's file extension.

Removed regex based file extention matcher competely. Requires the client to have `ext-fileinfo` extension.

### Release comments (new feature)
