### PR TITLE
Remove query feature

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -261,21 +261,6 @@ example above, `|ja|` and `|fr|` would become `|japanese|` and `|french|`
 respectively in the expression
 `ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi`.
 
-#### `query`
-This parameter tells WOVN.php which query parameters make pages unique. By
-default WOVN.io ignores query parameters when identifying unique pages. If
-you've created pages on WOVN.io with specific query parameters, you should add
-those query parameters to `wovn.ini` settings.
-
-For instance, if you have all three pages `https://my-website.com/index.php`,
-`https://my-website.com/index.php?login=1` and
-`https://my-website.com/index.php?forgot_password=1` on WOVN.io, then you should
-configure WOVN.php as below.
-```
-query[] = login
-query[] = forgot_password
-```
-
 #### `ignore_paths`
 This parameter tells WOVN.php to not localize content withing given directories.
 
@@ -325,11 +310,11 @@ ignore_class[] = no-translate
 ```
 
 #### `no_index_langs`
-This parameter tells WOVN.php which languages's HTML should be set `noindex` 
+This parameter tells WOVN.php which languages's HTML should be set `noindex`
 to avoid index by web crawler.
 
-For instance, if you want to avoid index for English pages, add `en` as below. 
-`<meta name="robots" content="noindex">` tag will be inserted inside `head` tag 
+For instance, if you want to avoid index for English pages, add `en` as below.
+`<meta name="robots" content="noindex">` tag will be inserted inside `head` tag
 for English pages.
 ```
 no_index_langs[] = en
@@ -372,8 +357,8 @@ be translated. When this setting is set to `1`, you may notice more server
 resource being used. This is because WOVN.php has to do some HTML parsing that
 our localization API usually does (for instance, to insert `hreflang`
 information). However, it will save web page loading time since it does not send
-a request to our API. If you experience no resource issues, we recommand you to 
-deactivate API requests for original language as below. 
+a request to our API. If you experience no resource issues, we recommand you to
+deactivate API requests for original language as below.
 
 ```
 disable_api_request_for_default_lang = 1
@@ -412,7 +397,7 @@ override_content_length = 1
 ```
 
 #### `check_amp`
-This parameter tells WOVN.php not to process your content if it is 
+This parameter tells WOVN.php not to process your content if it is
 an AMP (Accelerated Mobile Pages) compliant page.The default is disabled.
 If you enable this parameter, WOVN.php will not change the content.
 Therefore, we do not add any WOVN script tags.
@@ -422,12 +407,12 @@ check_amp = 1
 ```
 
 #### `site_prefix_path`
-This parameter tells WOVN.php to only process requests under the specified path. 
+This parameter tells WOVN.php to only process requests under the specified path.
 When translating URLs, the language identifier will be inserted after this prefix path.
 This parameter is valid only when `url_pattern_name` is `path`.
 
-For example, only `http://www.mysite.com/dir/*` is processed when `sitePrefixPath = dir` is set.  
-When `http://www.mysite.com/dir/index.html` is translated to English, language identifier will be added after specified path like `http://www.mysite.com/dir/en/index.html`.  
+For example, only `http://www.mysite.com/dir/*` is processed when `sitePrefixPath = dir` is set.
+When `http://www.mysite.com/dir/index.html` is translated to English, language identifier will be added after specified path like `http://www.mysite.com/dir/en/index.html`.
 URL which is not matched is not processed and snippet will not be inserted.
 
 ```
@@ -468,9 +453,9 @@ wovn_diagnostics_password = wovn_diagnostics_password
 
 ### `WOVN_TARGET_LANG`
 
-This environment variable sets the language code of the translation target as 
+This environment variable sets the language code of the translation target as
 retrieved from the HTTP request.
-The user can get the target language code from this environment variable and 
+The user can get the target language code from this environment variable and
 arbitrarily change the behavior of their program.
 
 For example.
@@ -502,10 +487,10 @@ SetEnv WOVN_CONFIG /path/to/wovn.ini
 
 ## 5. Bug Report
 
-To help us finding a solution to your issue we will require some information. 
-First we need to know on which web pages you encounter the issue, as well as 
-steps to reproduce. If possible, we would also need test accounts if your 
-issues occur on web pages behind authorization 
+To help us finding a solution to your issue we will require some information.
+First we need to know on which web pages you encounter the issue, as well as
+steps to reproduce. If possible, we would also need test accounts if your
+issues occur on web pages behind authorization
 (we recommend you to use a staging server for that matter).
 
 If your problems are happening on your server side (widget `<script>` tag not
@@ -537,6 +522,6 @@ To enable the Wovn Diagnostics Tool, please do the following tasks:
 2. Add `wovn_diagnostics_username`  in your `wovn.ini` configuration file, and set it to a username of your choice. The diagnostics tool cannot be used if a username is not set.
 3. Add `wovn_diagnostics_password`  in your `wovn.ini` configuration file, and set it to a password of your choice. The diagnostics tool cannot be used if a password is not set.
 
-The configuration will take effect immediately. 
+The configuration will take effect immediately.
 
 Please only enable the diagnostics tool when it is necessary to do so.

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,14 +13,14 @@ For English users: [English](README.en.md)
 
 WOVN.phpにはPHP 5.3以上が必要です。WOVN.phpにはサードパーティの依存関係はありません。
 
-設定によっては、Apacheモジュール `mod_rewrite` をインストールしたり有効化したりする必要があるかもしれません ( [2.3.2.項](#232-静的ウェブサイト) や [3.2.項](#32-任意パラメータ) を参照してください)。  
+設定によっては、Apacheモジュール `mod_rewrite` をインストールしたり有効化したりする必要があるかもしれません ( [2.3.2.項](#232-静的ウェブサイト) や [3.2.項](#32-任意パラメータ) を参照してください)。
 WOVN.phpはApache 2とNginxで動作確認済みです。両方のインストール方法を提供しています。
 
 ## 2. Getting Started
 
 ### 2.1. WOVN.php ダウンロード
 
-WOVN.phpをインストールするには、当社のGithubリポジトリからWOVN.phpを手動でダウンロードする必要があります。  
+WOVN.phpをインストールするには、当社のGithubリポジトリからWOVN.phpを手動でダウンロードする必要があります。
 WOVN.php のルートディレクトリは、ウェブサイトのディレクトリのルートに配置する必要があります。
 
 このドキュメントの残りの部分では、ウェブサイトのルートディレクトリを `/website/root/directory` とみなします。
@@ -31,21 +31,21 @@ $ wget https://github.com/WOVNio/WOVN.php/archive/master.zip -O WOVN.php.zip
 $ unzip WOVN.php.zip; mv WOVN.php-master WOVN.php
 ```
 
-**更新時の注意:**  
+**更新時の注意:**
 WOVN.phpを更新する必要がある場合は、`WOVN.php`ディレクトリのすべての内容を新しいバージョンの内容に置き換えるだけです。
 
 ### 2.2. 基本的な設定
 
 WOVN.ioプロジェクトでWOVN.phpを動作させるためには、設定ファイルを埋める必要があります。
 
-設定ファイルは `wovn.ini` という名前で、ウェブサイトのディレクトリのルートに置かなければなりません。  
+設定ファイルは `wovn.ini` という名前で、ウェブサイトのディレクトリのルートに置かなければなりません。
 サンプルファイルは `wovn.php/wovn.ini.sample` から始めることができます。
 
 ```
 $ cp WOVN.php/wovn.ini.sample wovn.ini
 ```
 
-このセクションでは、開始するための基本的な設定を説明します。  
+このセクションでは、開始するための基本的な設定を説明します。
 WOVN.phpの設定の詳細については、[セクション3.](#3-設定)を参照してください。
 
 開始するには、少なくともWOVN.ioのプロジェクトトークン、ウェブサイトのオリジナル言語、そして、ウェブサイトがWOVN.ioによって翻訳可能な言語を知っている必要があります。
@@ -77,12 +77,12 @@ WOVN.phpでウェブサイトを翻訳するためには、コンテンツイン
 
 ウェブページの生成方法に応じて、2つの有効化方法があります。
 
-ウェブページがPHPファイルで生成されている場合は、動的ウェブサイトの指示に従ってください。  
+ウェブページがPHPファイルで生成されている場合は、動的ウェブサイトの指示に従ってください。
 ウェブページが純粋なHTMLである場合は、静的なウェブサイトの手順に従ってください。
 
 #### 2.3.1. 動的ウェブサイト
 
-WebページがPHPファイルで生成される場合、コンテンツを生成する各PHPファイル内にWOVN.phpインターセプトスクリプトが必要になります。  
+WebページがPHPファイルで生成される場合、コンテンツを生成する各PHPファイル内にWOVN.phpインターセプトスクリプトが必要になります。
 以下のコードを使用してください。PHPファイルの先頭に挿入する必要があります。
 
 ```
@@ -91,23 +91,23 @@ require_once('/website/root/directory/WOVN.php/src/wovn_interceptor.php');
 
 #### 2.3.2. 静的ウェブサイト
 
-Webページが純粋なHTMLである場合、HTMLページを提供し翻訳するために使用する `wovn_index.php` ファイルを作成する必要があります。  
+Webページが純粋なHTMLである場合、HTMLページを提供し翻訳するために使用する `wovn_index.php` ファイルを作成する必要があります。
 私たちは、私たちが提供するサンプルから始めることをお勧めします。
 
 ```
 $ cp WOVN.php/wovn_index_sample.php wovn_index.php
 ```
 
-**SSIユーザの方への注意:**  
+**SSIユーザの方への注意:**
 サンプルの `wovn_index.php` を使用している場合は、コード内の `# SSI USER` の指示に従ってください。
 
-`wovn_index.php` を設定したら、HTMLページへのリクエストがすべて `wovn_index.php` にリダイレクトされるようにウェブサイトを設定する必要があります。  
-Apacheサーバを使っている場合は、[Apacheの説明](#apacheで-wovn_indexphp-にリダイレクト)に従ってください。  
+`wovn_index.php` を設定したら、HTMLページへのリクエストがすべて `wovn_index.php` にリダイレクトされるようにウェブサイトを設定する必要があります。
+Apacheサーバを使っている場合は、[Apacheの説明](#apacheで-wovn_indexphp-にリダイレクト)に従ってください。
 Nginx (Apacheなし) を使用している場合は、[Nginxの説明](#nginxで-wovn_indexphp-にリダイレクト) に従ってください。
 
 #### Apacheで `wovn_index.php` にリダイレクト
 
-リクエストを `wovn_index.php` にリダイレクトするには、`.htaccess` の設定に `mod_rewrite` Apache モジュールを使用することをお勧めします。  
+リクエストを `wovn_index.php` にリダイレクトするには、`.htaccess` の設定に `mod_rewrite` Apache モジュールを使用することをお勧めします。
 `mod_rewrite` モジュールのインストールと有効化については、[公式のドキュメント](https://httpd.apache.org/docs/2.4/)に従ってください( `mod_rewrite` がインストール済みで有効化されていない場合もあります)。
 
 以下に `.htaccess` の設定を示します。
@@ -181,7 +181,7 @@ WOVN.phpの設定は `wovn.ini` ファイルから行うことができます。
 
 ### 3.2. 任意パラメータ
 
-このセクションでは、WOVN.phpで使用できるオプションを詳しく説明します。  
+このセクションでは、WOVN.phpで使用できるオプションを詳しく説明します。
 それらのいくつかはあなたのウェブサイトの構造に依存していますが、他のものはより高度であり、パフォーマンスの最適化のために使用する必要があります。
 
 #### `url_pattern_name`
@@ -196,12 +196,12 @@ WOVN.php は 3 つのパターンをサポートしています。
 | パスパターン<br>`url_pattern_name = path`            | `https://my-website.com/index.php`<br>`https://my-website.com/ja/index.php`<br>`https://my-website.com/fr/index.php`         | *Original*<br>Japanese<br>French         |
 | サブドメインパターン<br>`url_pattern_name = subdomain`       | `https://my-website.com/index.php`<br>`https://ja.my-website.com/index.php`<br>`https://fr.my-website.com/index.php`         | *Original*<br>Japanese<br>French         |
 
-**パスパターンをお使いの方への注意事項:**  
+**パスパターンをお使いの方への注意事項:**
 PHPスクリプトで処理される前に、URLから言語コードを取り除くために、サーバーの設定を変更する必要があります。
 
-Apacheユーザの場合は、`.htaccess`の先頭に以下のルールを追加することができます。  
-Apacheモジュール `mod_rewrite` を有効化する必要があります。  
-`mod_rewrite` モジュールのインストールと有効化については、[公式のドキュメント](https://httpd.apache.org/docs/2.4/)に従ってください  
+Apacheユーザの場合は、`.htaccess`の先頭に以下のルールを追加することができます。
+Apacheモジュール `mod_rewrite` を有効化する必要があります。
+`mod_rewrite` モジュールのインストールと有効化については、[公式のドキュメント](https://httpd.apache.org/docs/2.4/)に従ってください
 (場合によっては、`mod_rewrite` が既にインストールされているのに有効化されていないこともあります)。
 
 ```
@@ -211,7 +211,7 @@ Apacheモジュール `mod_rewrite` を有効化する必要があります。
 </IfModule>
 ```
 
-Nginx ユーザーは、Nginx の設定ファイル (`/etc/nginx/conf.d/site.conf`) を更新する必要があります。  
+Nginx ユーザーは、Nginx の設定ファイル (`/etc/nginx/conf.d/site.conf`) を更新する必要があります。
 以下は、設定ファイルに追加する必要があるコードの抜粋です。
 
 ```
@@ -237,7 +237,7 @@ server {
 
 #### `lang_param_name`
 
-このパラメータは `url_pattern_name = query` の場合のみ有効です。  ページの言語を宣言するためのクエリパラメータ名を設定することができます。  
+このパラメータは `url_pattern_name = query` の場合のみ有効です。  ページの言語を宣言するためのクエリパラメータ名を設定することができます。
 この設定のデフォルト値は `lang_param_name = wovn` です。
 
 翻訳された英語ページのURLは、 URLの形式が以下のなります。
@@ -260,7 +260,7 @@ https://my-website.com/index.php?language=en
 
 #### `custom_lang_aliases`
 
-このパラメータでは、WOVN.phpで使用する言語コードを再定義することができます。  
+このパラメータでは、WOVN.phpで使用する言語コードを再定義することができます。
 例えば、"ja "の代わりに "japanese "を、"fr "の代わりに "french "を使いたい場合は、以下のように `wovn.ini` を設定します。
 
 ```
@@ -270,31 +270,12 @@ custom_lang_aliases[fr] = french
 
 **パスURLパターンをお使いの方へのご注意:**
 
-それに応じて `.htaccess` または Nginx の設定を更新する必要があります。  
+それに応じて `.htaccess` または Nginx の設定を更新する必要があります。
 上の例では、`|ja|` と `|fr|` は、式 `ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi` の中でそれぞれ `|japanese|` と `|french|` に変更する必要があります。
-
-#### `query`
-
-このパラメータは、ページを一意にするクエリパラメータを WOVN.php に伝えます。  
-デフォルトでは、WOVN.ioはユニークなページを識別する際にクエリパラメータを無視します。  
-WOVN.io上で特定のクエリパラメータを持つページを作成した場合は、それらのクエリパラメータを `wovn.ini` の設定に追加する必要があります。
-
-例えば、WOVN.io上に
-
-- `https://my-website.com/index.php`
-- `https://my-website.com/index.php?login=1`
-- `https://my-website.com/index.php?forgot_password=1`
-
-の3つのページがある場合、以下のようにWOVN.phpを設定する必要があります。
-
-```
-query[] = login
-query[] = forgot_password
-```
 
 #### `ignore_paths`
 
-このパラメータは、WOVN.php が指定したディレクトリ内のコンテンツを翻訳しないようにします。  
+このパラメータは、WOVN.php が指定したディレクトリ内のコンテンツを翻訳しないようにします。
 指定されたディレクトリは、URLパスの先頭にのみマッチします。
 
 例えば、ウェブサイトの `admin` ディレクトリを翻訳したくない場合は、以下のように WOVN.php を設定します。
@@ -323,7 +304,7 @@ https://my-website.com/adminpage
 
 このパラメータは `ignore_paths` と似ています ( [上記](#ignore_paths) を参照）。
 
-例えば、検索ページを翻訳しないようにしたい場合は、以下のように `wovn.ini` を設定します。  
+例えば、検索ページを翻訳しないようにしたい場合は、以下のように `wovn.ini` を設定します。
 WOVN.phpは `https://my-website.com/search/index.php` を翻訳するが、`https://my-website.com/search/01/` や `https://my-website.com/search/02/` は翻訳しません。
 
 ```
@@ -332,7 +313,7 @@ ignore_regex[] = /\/search\/\d\d\//
 
 #### `ignore_class`
 
-このパラメータは、翻訳時に無視すべき HTML フラグメントを WOVN.php に指定します。  
+このパラメータは、翻訳時に無視すべき HTML フラグメントを WOVN.php に指定します。
 `ignore_class` で与えられるクラスは HTML 要素のクラスです。無視されるクラスを持つすべてのHTML要素はWOVN.phpによって翻訳されません。
 
 例えば、クラス `ignore` と `no-translate` のすべての HTML 要素を無視したい場合は、以下のように WOVN.php を設定する必要があります。
@@ -346,7 +327,7 @@ ignore_class[] = no-translate
 
 このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
 
-例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。  
+例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。
 `<meta name="robots" content="noindex">` タグは英語ページの場合、`head` タグの中に挿入されます。
 
 ```
@@ -357,10 +338,10 @@ no_index_langs[] = en
 
 このパラメータは、WOVN.php にファイルに使用するエンコーディングを指定します。
 
-WOVN.php は 8 つのエンコーディングをサポートしています。  
+WOVN.php は 8 つのエンコーディングをサポートしています。
 `UTF-8`, `EUC-JP`, `SJIS`, `eucJP-win`, `SJIS-win`, `JIS`, `ISO-2022-JP` および `ASCII` です。
 
-エンコーディングを設定しなければ、WOVN.phpが自動的にエンコーディングを検出してくれます。  
+エンコーディングを設定しなければ、WOVN.phpが自動的にエンコーディングを検出してくれます。
 ただし、エンコーディングの検出に時間がかかる場合がありますので、より良いパフォーマンスを得るためにはエンコーディングを設定することをお勧めします。
 
 例えば、WebサイトのファイルがUTF-8でエンコードされている場合は、以下のようにWOVN.phpを設定する必要があります。
@@ -371,11 +352,11 @@ encoding = UTF-8
 
 #### `api_timeout`
 
-このパラメータは、WOVN.php に API を使用してコンテンツの翻訳に費やせる最大時間を指定します。  
-実際、私たちは翻訳ロジックのほとんどをWOVN.ioの別のサーバーに集中させており、WOVN.phpはほとんどの作業をそれらのサーバーに委譲しています。  
+このパラメータは、WOVN.php に API を使用してコンテンツの翻訳に費やせる最大時間を指定します。
+実際、私たちは翻訳ロジックのほとんどをWOVN.ioの別のサーバーに集中させており、WOVN.phpはほとんどの作業をそれらのサーバーに委譲しています。
 `api_timeout` を設定することで、WOVN.phpにAPIからの応答を待つ時間を伝えます。
 
-APIからの応答に時間がかかりすぎると、翻訳元のコンテンツが提供されます。  
+APIからの応答に時間がかかりすぎると、翻訳元のコンテンツが提供されます。
 デフォルトでは、`api_timeout` は1秒に設定されています。
 
 例えば、デフォルトのタイムアウトを2秒まで増やしたい場合は、以下のように `wovn.ini` を設定します。
@@ -388,11 +369,11 @@ api_timeout = 2
 
 このパラメータは、WOVN.php が元の言語でコンテンツをリクエストした際に翻訳APIを使用するかどうかを指定します。
 
-デフォルトでは、`disable_api_request_for_default_lang` オプションは `0` (false) に設定されています。  
+デフォルトでは、`disable_api_request_for_default_lang` オプションは `0` (false) に設定されています。
 これは、コンテンツが翻訳されていなくても WOVN.php が 翻訳API を使用することを意味します。
 
-この設定を `1` にすると、サーバーリソースの使用量が増えることに気づくかもしれません。  
-これは、WOVN.phpで翻訳APIが通常行うHTMLのパースを行わなければならないからです(例えば、`hreflang`情報を挿入するなど)。  
+この設定を `1` にすると、サーバーリソースの使用量が増えることに気づくかもしれません。
+これは、WOVN.phpで翻訳APIが通常行うHTMLのパースを行わなければならないからです(例えば、`hreflang`情報を挿入するなど)。
 しかし、WOVN.phpはAPIにリクエストを送信しないので、ウェブページの読み込み時間を短縮することができます。
 
 リソースに問題がなければ、以下のように翻訳元言語のAPIリクエストを停止することをお勧めします。
@@ -403,20 +384,20 @@ disable_api_request_for_default_lang = 1
 
 #### `use_proxy`
 
-このパラメータは、WOVN.php にコンテンツをプロキシ経由で提供するかどうかを指定します。  
+このパラメータは、WOVN.php にコンテンツをプロキシ経由で提供するかどうかを指定します。
 デフォルトでは、この設定は `0` (false) に設定されています。
 
-プロキシを使ってコンテンツを提供している場合、WOVN.phpはリクエストされたURLに基づいて情報を収集する際にそれを知る必要があります。  
+プロキシを使ってコンテンツを提供している場合、WOVN.phpはリクエストされたURLに基づいて情報を収集する際にそれを知る必要があります。
 その場合は、`use_proxy` を `1` (true) に設定する必要があります。
 
 ```
 use_proxy = 1
 ```
 
-`use_proxy` がアクティブな場合、WOVN.php は HTTP ヘッダ `X-Forwarded-Proto` と `X-Forwarded-Host` から URL プロトコルとホストを利用しようとします。  
+`use_proxy` がアクティブな場合、WOVN.php は HTTP ヘッダ `X-Forwarded-Proto` と `X-Forwarded-Host` から URL プロトコルとホストを利用しようとします。
 これらはプロキシ転送の標準フィールドです。
 
-さらに、WOVN.phpはHTTPヘッダ`X-Forwarded-Request-Uri`を探します。  
+さらに、WOVN.phpはHTTPヘッダ`X-Forwarded-Request-Uri`を探します。
 これは、WOVN.php がクライアントからリクエストされた元の URI (すなわち "/japan/tokyo.html") を参照するために手動で設定することができます。
 
 mod\_proxy と ProxyPass ディレクティブを使用している場合、 例えば、この HTTP ヘッダは RequestHeader ディレクティブで以下のように設定することができます。
@@ -429,7 +410,7 @@ RequestHeader    setifempty X-Forwarded-Request-Uri "expr=%{REQUEST_URI}"
 
 #### `override_content_length`
 
-このパラメータはWOVN.phpにレスポンスヘッダ「Content-Length」を更新するかどうかを指定します。  
+このパラメータはWOVN.phpにレスポンスヘッダ「Content-Length」を更新するかどうかを指定します。
 パフォーマンスを最適化するために、デフォルトでは `override_content_length` が `0` (false) に設定されています。
 
 レスポンスヘッダ「Content-Length」の更新を維持する必要がある場合は、`override_content_length` を `1` (true) に設定してください。
@@ -440,8 +421,8 @@ override_content_length = 1
 
 #### `check_amp`
 
-このパラメータは、AMP (Accelerated Mobile Pages) 準拠のページであれば WOVN.PHP がコンテンツを処理しないようにします。  
-このパラメータを有効にすると、WOVN.phpはコンテンツの変更をしません。  
+このパラメータは、AMP (Accelerated Mobile Pages) 準拠のページであれば WOVN.PHP がコンテンツを処理しないようにします。
+このパラメータを有効にすると、WOVN.phpはコンテンツの変更をしません。
 そのため、WOVNスクリプトのタグを追加することはありません。
 
 #### `site_prefix_path`
@@ -460,7 +441,7 @@ site_prefix_path = dir1/dir2
 
 ### `WOVN_TARGET_LANG`
 
-この環境変数は、HTTPリクエストから取得した翻訳対象の言語コードを設定します。  
+この環境変数は、HTTPリクエストから取得した翻訳対象の言語コードを設定します。
 ユーザーは、この環境変数からターゲット言語のコードを取得し、プログラムの動作を任意に変更することができます。
 
 例えば、以下のように
@@ -472,7 +453,7 @@ if ($_ENV['WOVN_TARGET_LANG'] == 'fr') {
 
 ### `WOVN_CONFIG`
 
-この環境変数は、ユーザがデフォルトの `wovn.ini` のパスを任意の設定ファイルのパスに変更することを可能にします。  
+この環境変数は、ユーザがデフォルトの `wovn.ini` のパスを任意の設定ファイルのパスに変更することを可能にします。
 例えば、以下のように変更することができます。
 
 ユーザは `wovn_interceptor.php` を読み込む前に `$_SERVER['WOVN_CONFIG']` を設定することができます。
@@ -491,9 +472,9 @@ SetEnv WOVN_CONFIG /path/to/wovn.ini
 
 ## 5. バグ報告
 
-お客様の問題を解決するためには、いくつかの情報が必要です。  
-まず、どのウェブページで問題が発生したのか、再現するための手順を知る必要があります。  
-可能であれば、問題が認証されていないウェブページで発生している場合は、テストアカウントも必要になります  
+お客様の問題を解決するためには、いくつかの情報が必要です。
+まず、どのウェブページで問題が発生したのか、再現するための手順を知る必要があります。
+可能であれば、問題が認証されていないウェブページで発生している場合は、テストアカウントも必要になります
 （そのためにはステージングサーバを使用することをお勧めします）。
 
 問題がサーバ側で発生している場合 (ウィジェット `<script>` タグが挿入されていない、言語が検出されない、リダイレクトが正しく処理されていないなど)、通常はより多くの情報が必要です。

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -64,26 +64,9 @@ class Headers
             $this->pathname = $this->removeLang($exploded[0], $this->lang());
         }
         $this->query = (!isset($exploded[1])) ? '' : $exploded[1];
-        $urlQuery = $this->removeLang($this->query, $this->lang());
-        $urlQuery = strlen($urlQuery) > 0 ? '?' . $urlQuery : '';
-        $this->url = $this->protocol . '://' . $this->host . $this->pathname . $urlQuery;
-        if (count($store->settings['query']) > 0) {
-            $queryVals = array();
-            foreach ($store->settings['query'] as $qv) {
-                $rp = '/(^|&)(?P<queryVal>' . $qv . '[^&]+)(&|$)/';
-                preg_match($rp, $this->query, $match);
-                if (isset($match['queryVal'])) {
-                    array_push($queryVals, $match['queryVal']);
-                }
-            }
-            if (count($queryVals) > 0) {
-                asort($queryVals);
-                $this->query = '?' . implode('&', $queryVals);
-            }
-        } else {
-            $this->query = '';
-        }
         $this->query = $this->removeLang($this->query, $this->lang());
+        $urlQuery = strlen($this->query) > 0 ? '?' . $this->query : '';
+
         $this->pathnameKeepTrailingSlash = $this->pathname;
         $this->pathname = preg_replace('/\/$/', '', $this->pathname);
         $this->url = $this->protocol . '://' . $this->host . $this->pathname . $urlQuery;
@@ -312,15 +295,7 @@ class Headers
     public function getDocumentURI()
     {
         $url = $this->env['REQUEST_URI'];
-        $url_arr = parse_url($url);
 
-        if ($url_arr && array_key_exists('query', $url_arr)) {
-            $query = $url_arr['query'];
-            $uri = str_replace(array($query,'?'), '', $url);
-        } else {
-            $uri = $url;
-        }
-
-        return $this->removeLang($uri, $this->lang());
+        return $this->removeLang($url, $this->lang());
     }
 }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -65,7 +65,6 @@ class Store
             'url_pattern_name' => 'query',
             'lang_param_name' => 'wovn',
             'url_pattern_reg' => '((\?.*&)|\?)wovn=(?P<lang>[^&]+)(&|$)',
-            'query' => array(),
             'widget_url' => '//j.wovn.io/1',
             'api_url' => 'https://wovn.global.ssl.fastly.net/v0/',
             'api_error_host' => 'api.wovn.io',
@@ -118,16 +117,6 @@ class Store
 
         // GETTING THE LANGUAGE AND SETTING IT AS CODE
         $this->settings['default_lang'] = Lang::getCode($this->settings['default_lang']);
-
-        // Gettting the query params array, adding = if missing and sorting
-        if (!empty($this->settings['query'])) {
-            foreach ($this->settings['query'] as $k => $q) {
-                if (!preg_match('/=$/', $q)) {
-                    $this->settings['query'][$k] = $q . '=';
-                }
-            }
-            sort($this->settings['query'], SORT_STRING);
-        }
 
         if (!empty($this->settings['site_prefix_path'])) {
             $this->settings['site_prefix_path'] = trim($this->settings['site_prefix_path'], '/');

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -923,7 +923,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $env = array( 'REQUEST_URI' => '/en/path?page=1&wovn=vi');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
-        $this->assertEquals('/en/path', $headers->getDocumentURI());
+        $this->assertEquals('/en/path?page=1&wovn=vi', $headers->getDocumentURI());
     }
 
     public function testGetDocumentURIWithPathPattern()
@@ -932,7 +932,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $env = array( 'REQUEST_URI' => '/en/path?page=1');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
-        $this->assertEquals('/path', $headers->getDocumentURI());
+        $this->assertEquals('/path?page=1', $headers->getDocumentURI());
     }
 
     public function testUrlKeepTrailingSlashWithoutProxy()

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -923,7 +923,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $env = array( 'REQUEST_URI' => '/en/path?page=1&wovn=vi');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
-        $this->assertEquals('/en/path?page=1&wovn=vi', $headers->getDocumentURI());
+        $this->assertEquals('/en/path?page=1', $headers->getDocumentURI());
     }
 
     public function testGetDocumentURIWithPathPattern()

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -85,65 +85,6 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($store->isValid());
     }
 
-    public function testQuerySettingOneParam()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array(
-            'project_token = "T0k3N"',
-            'query[] = "a"',
-            'backend_host = "rs1.wovn.io"',
-            'backend_port = "6379"',
-            'default_lang = "English"'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals(array('a='), $store->settings['query']);
-    }
-
-    public function testQuerySettingTwoParam()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array(
-            'project_token = "T0k3N"',
-            'query[] = "a"',
-            'query[] = "b"',
-            'backend_host = "rs1.wovn.io"',
-            'backend_port = "6379"',
-            'default_lang = "English"'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals(array('a=', 'b='), $store->settings['query']);
-    }
-
-    public function testQuerySettingTwoParamsSorting()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array(
-            'project_token = "T0k3N"',
-            'query[] = "b"',
-            'query[] = "a"',
-            'backend_host = "rs1.wovn.io"',
-            'backend_port = "6379"',
-            'default_lang = "English"'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals(array('a=', 'b='), $store->settings['query']);
-    }
-
     public function testEncodingSetting()
     {
         $file_config = dirname(__FILE__) . '/test_config.ini';
@@ -397,8 +338,7 @@ class StoreTest extends \PHPUnit_Framework_TestCase
             array('path', '/dir1/dir2', 'dir1/dir2'),
             array('path', '/dir1/dir2/', 'dir1/dir2'),
             array('path', 'dir1/dir2/', 'dir1/dir2'),
-            array('subdomain', null, null),
-            array('query', null, null),
+            array('subdomain', null, null)
         );
         foreach ($testCases as $case) {
             list($url_pattern_name, $site_prefix_path, $expected_site_prefix_path) = $case;


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

### Comments
This refers to the `query[]=foo` setting that was apparently a thing. It was added on the very first commit of WOVN.php, but I am not convinced it is actually used. I am assuming this was carried over from the old wovnphp that did not use html swapper.

Equalizer _does_ have a query parameter feature, where you can specify which query parameters should be considered a "unique" page in our system. However, this is no longer any concern of backends. This logic is done in the `js_data` request during auto page add logic (the fact that the widget does not have any code for this feature is also telling). 

WOVN.php already sends the full URL including query params to HTML swapper (regardless of this setting). Then HTML swapper forwards this to the js_data request. So I am not sure that this setting actually _does_ anything right now other than creating a bunch of variables.

So my opinion is we can delete it. Please offer justification if you think we still need this.


### Release comments (new feature)
