### PR TITLE
remove REQUEST_URI fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .phplint-cache
 .log
 .idea/
+.vscode/
 vendor/
 composer.phar
 test/integration/test/integration/wovn_index_sample_workspace

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -45,9 +45,6 @@ class Headers
         } else {
             $this->originalHost = $env['HTTP_HOST'];
         }
-        if (!isset($env['REQUEST_URI'])) {
-            $env['REQUEST_URI'] = $env['PATH_INFO'] . (strlen($env['QUERY_STRING']) === 0 ? '' : '?' . $env['QUERY_STRING']);
-        }
 
         if ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_REQUEST_URI'])) {
             $this->originalPath = $env['HTTP_X_FORWARDED_REQUEST_URI'];

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -141,17 +141,6 @@ class Utils
         }
         return false;
     }
-
-    private static function getEnv($env, $keys)
-    {
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $env)) {
-                return $env[$key];
-            }
-        }
-        return '';
-    }
-
     /*
      * Return path component of $uri
      */


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

### Comments
`$env['REQUEST_URI']` should always be available. It is only missing when running PHP in CLI mode which is not the case for web servers. So I think this is a useless assignment.

After reading on https://www.php.net/manual/en/reserved.variables.server.php, I think this was not implemented correctly anyway. $_SERVER['PATH_INFO'] does not contain the full request path, so I suspect this code has not really been used.

I would like to reduce the number of environment variables we access.
 
### Release comments (new feature)
