### PR TITLE
Fix wovn-ignore mark

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.5.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.5.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -366,7 +366,7 @@ class HtmlConverter
      */
     function _removeWovnIgnore($node, $marker)
     {
-        if ($node->getAttribute('wovn-ignore') || $node->getAttribute('data-wovn-ignore')) {
+        if ($node->getAttribute('wovn-ignore') !== false  || $node->getAttribute('data-wovn-ignore') != false) {
             $this->putReplaceMarker($node, $marker);
         }
     }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -366,7 +366,7 @@ class HtmlConverter
      */
     function _removeWovnIgnore($node, $marker)
     {
-        if ($node->getAttribute('wovn-ignore') !== false  || $node->getAttribute('data-wovn-ignore') != false) {
+        if ($node->hasAttribute('wovn-ignore') || $node->hasAttribute('data-wovn-ignore')) {
             $this->putReplaceMarker($node, $marker);
         }
     }

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -405,7 +405,7 @@ class SimpleHtmlDomNode {
     function __isset($name)
     {
         $val = $this->get_attr_val($this->attribute, $name);
-        return isset($val) && $val !== false ;
+        return $val !== false;
     }
 
   /*

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -280,7 +280,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if ($val) {
+        if (isset($val)) {
             return $this->convert_text($val);
         }
 

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -300,6 +300,7 @@ class SimpleHtmlDomNode {
     {
         $text_len = strlen($attr_text);
         $name_pos = stripos($attr_text, $name);
+        error_log('name_pos: ' . json_encode($name_pos));
         if ($name_pos === false) return false;
         if ($name_pos >= $text_len) return true;
 
@@ -405,7 +406,7 @@ class SimpleHtmlDomNode {
     function __isset($name)
     {
         $val = $this->get_attr_val($this->attribute, $name);
-        return $val === true || $val === '';
+        return isset($val) && $val !== false ;
     }
 
   /*

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -280,7 +280,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if (isset($val)) {
+        if ($val) {
             return $this->convert_text($val);
         }
 
@@ -404,15 +404,8 @@ class SimpleHtmlDomNode {
 
     function __isset($name)
     {
-        switch ($name)
-        {
-            case 'outertext': return true;
-            case 'innertext': return true;
-            case 'plaintext': return true;
-        }
-        //no value attr: nowrap, checked selected...
-        // return (array_key_exists($name, $this->attr)) ? true : isset($this->attr[$name]);
-        return false;
+        $val = $this->get_attr_val($this->attribute, $name);
+        return $val === true || $val === '';
     }
 
   /*
@@ -511,7 +504,7 @@ class SimpleHtmlDomNode {
     // camel naming conventions
     function getAttribute($name) {return $this->__get($name);}
     function setAttribute($name, $value) {$this->__set($name, $value);}
-    // function hasAttribute($name) {return $this->__isset($name);}
+    function hasAttribute($name) {return $this->__isset($name);}
     function removeAttribute($name) {$this->__set($name, null);}
     function getElementById($id) {return $this->find("#$id", 0);}
     function getElementsById($id, $idx=null) {return $this->find("#$id", $idx);}

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -300,7 +300,6 @@ class SimpleHtmlDomNode {
     {
         $text_len = strlen($attr_text);
         $name_pos = stripos($attr_text, $name);
-        error_log('name_pos: ' . json_encode($name_pos));
         if ($name_pos === false) return false;
         if ($name_pos >= $text_len) return true;
 

--- a/src/wovnio/wovnphp/CookieLang.php
+++ b/src/wovnio/wovnphp/CookieLang.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Wovnio\Wovnphp;
 
 class CookieLang

--- a/test/helpers/StoreAndHeadersFactory.php
+++ b/test/helpers/StoreAndHeadersFactory.php
@@ -2,6 +2,7 @@
 namespace Wovnio\Test\Helpers;
 
 require_once 'test/helpers/EnvFactory.php';
+require_once 'src/wovnio/wovnphp/CookieLang.php';
 
 use Wovnio\Wovnphp\CookieLang;
 use Wovnio\Wovnphp\Store;

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -607,29 +607,77 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testConvertToAppropriateBodyForApiWithWovnSnippet()
+    {
+        $original_html = '<html>'.
+            '<head>'.
+            '<script src="//j.wovn.io/1" data-wovnio="key=123456" async></script>'.
+            '</head>'.
+            '<body>'.
+            '<a>hello</a>'.
+            '</body>'.
+            '</html>';
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
+        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
+        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeSnippet');
+
+        $this->assertEquals(0, count($marker->keys()));
+        $expected_html = '<html>'.
+            '<head>'.
+            '</head>'.
+            '<body>'.
+            '<a>hello</a>'.
+            '</body>'.
+            '</html>';
+        $this->assertEquals($expected_html, $translated_html);
+    }
+
     public function testConvertToAppropriateBodyForApiWithWovnIgnore()
     {
-        $html = '<html><body><a wovn-ignore>hello</a></body></html>';
+        $original_html = '<html>'.
+            '<body>'.
+            '<a wovn-ignore>hello</a>'.
+            '<a wovn-ignore="">wovn</a>'.
+            '<a wovn-ignore="true">world</a>'.
+            '</body>'.
+            '</html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
-        $keys = $marker->keys();
+        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
+        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeWovnIgnore');
 
-        $this->assertEquals(1, count($keys));
-        $this->assertEquals("<html><body><a wovn-ignore>$keys[0]</a></body></html>", $translated_html);
+        $this->assertEquals(3, count($marker->keys()));
+        $expected_html = '<html>'.
+            '<body>'.
+            '<a wovn-ignore><!-- __wovn-backend-ignored-key-0 --></a>'.
+            '<a wovn-ignore=""><!-- __wovn-backend-ignored-key-1 --></a>'.
+            '<a wovn-ignore="true"><!-- __wovn-backend-ignored-key-2 --></a>'.
+            '</body>'.
+            '</html>';
+        $this->assertEquals($expected_html, $translated_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithDataWovnIgnore()
     {
-        $html = '<html><body><a data-wovn-ignore>hello</a></body></html>';
+        $original_html = '<html>'.
+            '<body>'.
+            '<a data-wovn-ignore>hello</a>'.
+            '<a data-wovn-ignore="">wovn</a>'.
+            '<a data-wovn-ignore="true">world</a>'.
+            '</body>'.
+            '</html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
-        $keys = $marker->keys();
+        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
+        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeWovnIgnore');
 
-        $this->assertEquals(1, count($keys));
-        $this->assertEquals('<!-- __wovn-backend-ignored-key-0 -->', $keys[0]);
-        $this->assertEquals("<html><body><a data-wovn-ignore>$keys[0]</a></body></html>", $translated_html);
+        $this->assertEquals(3, count($marker->keys()));
+        $expected_html = '<html>'.
+            '<body>'.
+            '<a data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></a>'.
+            '<a data-wovn-ignore=""><!-- __wovn-backend-ignored-key-1 --></a>'.
+            '<a data-wovn-ignore="true"><!-- __wovn-backend-ignored-key-2 --></a>'.
+            '</body>'.
+            '</html>';
+        $this->assertEquals($expected_html, $translated_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithCustomIgnoreClass()

--- a/test/unit/modified_vendor/SimpleHtmlDomTest.php
+++ b/test/unit/modified_vendor/SimpleHtmlDomTest.php
@@ -10,59 +10,27 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetAttribute()
     {
-        $html = '<html><body><div class="hello" data-dummy="dummy"></div></body>';
+        $html = '<html><body>'.
+            '<div'.
+            ' class="this is class"'.
+            ' data-dummy-1="double quote"'.
+            ' data-dummy-2=\'single quote\''.
+            ' data-dummy-3=without-quote'.
+            ' data-dummy-4=""'.
+            ' data-dummy-5=\'\''.
+            ' data-dummy-6'.
+            '></div>'.
+            '</body></html>';
         $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
         $nodes = $this->getTagNodes($dom, 'div');
         $this->assertEquals(1, count($nodes));
-        foreach ($nodes as $node) {
-            $this->assertEquals('hello', $node->getAttribute('class'));
-        }
-    }
-
-    public function testGetAttributeWithSingleQuote()
-    {
-        $html = "<html><body><div class='hello' data-dummy='dummy'></div></body>";
-        $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
-        $nodes = $this->getTagNodes($dom, 'div');
-        $this->assertEquals(1, count($nodes));
-        foreach ($nodes as $node) {
-            $this->assertEquals('hello', $node->getAttribute('class'));
-        }
-    }
-
-    public function testGetAttributeWithoutQuote()
-    {
-        $html = "<html><body><div class=hello  data-dummy=dummy></div></body>";
-        $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
-        $nodes = $this->getTagNodes($dom, 'div');
-        $this->assertEquals(1, count($nodes));
-        foreach ($nodes as $node) {
-            $this->assertEquals('hello', $node->getAttribute('class'));
-        }
-    }
-
-    public function testGetAttributeWithoutValue()
-    {
-        $html = "<html><body><div wovn-ignore></div></body>";
-        $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
-        $nodes = $this->getTagNodes($dom, 'div');
-        $this->assertEquals(1, count($nodes));
-        foreach ($nodes as $node) {
-            $this->assertEquals(true, $node->getAttribute('wovn-ignore'));
-        }
-    }
-
-    public function testGetAttributeWithMultipleAttribute()
-    {
-        $html = "<html><body><div class='hello' style=\"test-style\" data-test=test-data data-dummy1=\"dummy\" data-dummy2='dummy' data-dummy3=dummy></div></body>";
-        $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
-        $nodes = $this->getTagNodes($dom, 'div');
-        $this->assertEquals(1, count($nodes));
-        foreach ($nodes as $node) {
-            $this->assertEquals('hello', $node->getAttribute('class'));
-            $this->assertEquals('test-style', $node->getAttribute('style'));
-            $this->assertEquals('test-data', $node->getAttribute('data-test'));
-        }
+        $this->assertEquals('this is class', $nodes[0]->getAttribute('class'));
+        $this->assertEquals('double quote', $nodes[0]->getAttribute('data-dummy-1'));
+        $this->assertEquals('single quote', $nodes[0]->getAttribute('data-dummy-2'));
+        $this->assertEquals('without-quote', $nodes[0]->getAttribute('data-dummy-3'));
+        $this->assertEquals('', $nodes[0]->getAttribute('data-dummy-4'));
+        $this->assertEquals('', $nodes[0]->getAttribute('data-dummy-5'));
+        $this->assertEquals(true, $nodes[0]->getAttribute('data-dummy-6'));
     }
 
     public function testSetAttribute()
@@ -152,7 +120,17 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
 
     public function testHasAttribute()
     {
-        $html = '<html><body><div class="test1" data-dummy-1="test2" data-dummy-2="" data-dummy-3></div></body>';
+        $html = '<html><body>'.
+            '<div'.
+            ' class="test1"'.
+            ' data-dummy-1="test2"'.
+            ' data-dummy-2=\'test3\''.
+            ' data-dummy-3=test4'.
+            ' data-dummy-4=""'.
+            ' data-dummy-5=\'\''.
+            ' data-dummy-6'.
+            '></div>'.
+            '</body></html>';
         $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
         $nodes = $this->getTagNodes($dom, 'div');
         $this->assertEquals(1, count($nodes));
@@ -160,7 +138,10 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-1'));
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-2'));
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-3'));
-        $this->assertEquals(false, $nodes[0]->hasAttribute('data-dummy-4'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-4'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-5'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-6'));
+        $this->assertEquals(false, $nodes[0]->hasAttribute('data-dummy-7'));
     }
 
     private function getTagNodes($dom, $tag_name)

--- a/test/unit/modified_vendor/SimpleHtmlDomTest.php
+++ b/test/unit/modified_vendor/SimpleHtmlDomTest.php
@@ -150,6 +150,19 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<html><body><div class=\'multiple\' style="attribute" data-test=world data-dummy1="dummy" data-dummy2=\'dummy\' data-dummy3=dummy></div></body>', $replaced_html);
     }
 
+    public function testHasAttribute()
+    {
+        $html = '<html><body><div class="test1" data-dummy-1="test2" data-dummy-2="" data-dummy-3></div></body>';
+        $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
+        $nodes = $this->getTagNodes($dom, 'div');
+        $this->assertEquals(1, count($nodes));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('class'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-1'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-2'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-3'));
+        $this->assertEquals(false, $nodes[0]->hasAttribute('data-dummy-4'));
+    }
+
     private function getTagNodes($dom, $tag_name)
     {
         $self = $this;

--- a/test/unit/modified_vendor/SimpleHtmlDomTest.php
+++ b/test/unit/modified_vendor/SimpleHtmlDomTest.php
@@ -129,6 +129,7 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
             ' data-dummy-4=""'.
             ' data-dummy-5=\'\''.
             ' data-dummy-6'.
+            ' data-dummy-7=false'.
             '></div>'.
             '</body></html>';
         $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
@@ -141,7 +142,8 @@ class SimpleHtmlDomTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-4'));
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-5'));
         $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-6'));
-        $this->assertEquals(false, $nodes[0]->hasAttribute('data-dummy-7'));
+        $this->assertEquals(true, $nodes[0]->hasAttribute('data-dummy-7'));
+        $this->assertEquals(false, $nodes[0]->hasAttribute('data-dummy-100'));
     }
 
     private function getTagNodes($dom, $tag_name)


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
`$node->getAttribute('wovn-ignore')` is falsy, even if the attribute exists.
I added `hasAttribute` method to check having `wovn-ignore` or not.

```
<span wovn-ignore>xxx</span> -> marked
<span wovn-ignore="true">xxx</span> -> marked
<span wovn-ignore="">xxx</span> -> not marked (should mark)
```

### Comments

### Release comments (new feature)
