### PR TITLE
Enable XDebug in tests

### DIFF
--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -119,6 +119,11 @@ vendor/bin/phpunit --configuration phpunit_integration.xml
 ## Nginx environment
 You can use with Nginx, if you change from `apache.yml` to `nginx.yml` in `makefile`.
 
-## With Wordpress environment
-You can use with Wordpress, if you change from `apache.yml` to `wp_apache.yml` in `makefile`.
-You can set wordpress directory with `working_dir: /var/www/html/anywhere` in `wp_apache.yml`.
+## With WordPress environment
+You can use with WordPress, if you change from `apache.yml` to `wp_apache.yml` in `makefile`.  
+Don't forget to configure the followings.
+- .htaccess
+- wovn_intercepter.php
+
+### Change directory of WordPress files
+You can change WordPress files directory with `working_dir: /var/www/html/anywhere` in `wp_apache.yml`.

--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -83,25 +83,24 @@ vendor/bin/phpunit --filter <test name> <relative path to target test file>
 `--filter`: You can specify test name.  
 `--debug`: You can see test details.
 
-### Run unit tests
+### Run tests
 If you run the following command, tests will be run with PHP in your local PC.
 ```
 vendor/bin/phpunit
 ```
 
-When you want to run tests in specific version of PHP, you can do that by the following way.  
-1. Change PHP version by changing `DOCKER_IMAGE` in `makefile`.
+When you want to run tests with Docker, you can do that by the following way.  
 
-2. Run docker with `docker/test.yml` (`DOCKER_COMPOSE_YML` in `makefile`)
+1. Run Docker with `docker/test.yml` (`DOCKER_COMPOSE_YML` in `makefile`)
 ```
-make stop && make start
+make stop && make start_test
 ```
 
-3. Start `Listen for XDebug in tests` from VSCode.
+2. Start `Listen for XDebug in tests` from VSCode.
 You can set break point.  
 If you don't need to debug, skip this step.
 
-4. Run tests
+3. Run tests
 ```
 make test_unit_with_docker
 make test_integration_with_docker

--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -1,54 +1,117 @@
-# WOVN.php debug environment with Apache
+# WOVN.php debug environment
 
-## Start
+## How to use docker
+### Start
 1. build docker image  
-Build docker for the first time.
+Build docker is needed only for the first time.
 ```
 make build
 ```
 
-2. Set wovn.ini  
+2. Configure wovn.ini  
 Rewrite wovn.ini.sample with your config.
 
-3. Set your .htaccess
+3. Configure your .htaccess  
 Rewrite htaccess_sample with your config.
 
 4. Run docker  
 Run the following command.  
-You should be able to see the content located at `/docker/public` when you access `localhost`.
+You should be able to see the content located at `docker/public` when you access `localhost`.
 ```
 make start
 ```
 
-## Stop
+### Stop
+Stop docker.  
+Make sure that old docker is stopped before start again.
 ```
 make stop
 ```
 
-## Remove all
+### Remove all
+Remove docker and those volumes.
 ```
 make clean
 ```
 
-## Run test with PHP version which you like
-1. Change makefile to use `test.yml`.
+### Debug by XDebug
+#### XDebug configuration for VSCode
+You can use the following setting for `launch.json`.  
+After start debugging, you can break by break points.  
 ```
-DOCKER_COMPOSE_YML = docker/test.yml
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9001,
+            "pathMappings": {
+                "/var/www/html/WOVN.php": "${workspaceRoot}",
+            },
+        },
+        {
+            "name": "Listen for XDebug in tests",
+            "type": "php",
+            "request": "launch",
+            "port": 9001,
+            "pathMappings": {
+                "/opt/project": "${workspaceRoot}"
+            },
+        }
+    ]
+}
 ```
-2. Run docker 
+
+#### Debug by XDebug
+Start `Listen for XDebug` from `Run` menu in VSCode.  
+You can set break point.  
+
+If you have a trouble, Check `zend_extension` in `docker/php.ini`.  
+You can see `zend_extension` info by running `phpinfo()` method in PHP.  
+
+You can see log of XDebug by `docker/apache/log/xdebug.log`.
+
+## How to run tests in your local
+
+### Phpunit options tips
+You can run spesific tests by the followings way.
+```
+vendor/bin/phpunit --filter <test name> <relative path to target test file>
+```
+`--filter`: You can specify test name.  
+`--debug`: You can see test details.
+
+### Run unit tests
+If you run the following command, tests will be run with PHP in your local PC.
+```
+vendor/bin/phpunit
+```
+
+When you want to run tests in specific version of PHP, you can do that by the following way.  
+1. Change PHP version by changing `DOCKER_IMAGE` in `makefile`.
+
+2. Run docker with `docker/test.yml` (`DOCKER_COMPOSE_YML` in `makefile`)
 ```
 make stop && make start
 ```
-3. Enable to run command inside docker
+
+3. Start `Listen for XDebug in tests` from VSCode.
+You can set break point.  
+If you don't need to debug, skip this step.
+
+4. Run tests
+```
+make test_unit_with_docker
+make test_integration_with_docker
+```
+Or you can run it step by step.
 ```
 docker exec -it apache bash
 ```
-4. Go to target dir
 ```
 cd /opt/project
-```
-5. Run tests
-```
 vendor/bin/phpunit
 vendor/bin/phpunit --configuration phpunit_integration.xml
 ```

--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -96,7 +96,8 @@ When you want to run tests with Docker, you can do that by the following way.
 make stop && make start_test
 ```
 
-2. Start `Listen for XDebug in tests` from VSCode.
+2. Start `Listen for XDebug in tests` from VSCode.  
+Start `Listen for XDebug in tests` from `Run` menu in VSCode.  
 You can set break point.  
 If you don't need to debug, skip this step.
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,7 @@
-FROM php:7.3-fpm
+# set docker image
+ARG DOCKER_IMAGE="php:7.4-apache"
+
+FROM ${DOCKER_IMAGE}
 RUN apt-get update
 
 # install xdebug

--- a/docker/test.yml
+++ b/docker/test.yml
@@ -2,7 +2,9 @@ version: '3'
 services:
   apache:
     container_name: apache
-    image: ${DOCKER_IMAGE}
+    build:
+      context: ./apache
+      dockerfile: Dockerfile
     privileged: true
     ports:
       - 80:80

--- a/docker/wp_apache.yml
+++ b/docker/wp_apache.yml
@@ -20,8 +20,6 @@ services:
       - ./public:/var/www/html
       - ../:/var/www/html/WOVN.php
       - ../wovn.ini.sample:/var/www/html/wovn.ini
-      - ../wovn_index_sample.php:/var/www/html/wovn_index.php
-      - ../htaccess_sample:/var/www/html/.htaccess
   mysql:
     container_name: mysql
     image: mysql:5.7

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
-DOCKER_COMPOSE_YML = docker/apache.yml
-# DOCKER_COMPOSE_YML = docker/test.yml
-DOCKER_IMAGE = php:7.4-apache
+# DOCKER_COMPOSE_YML = docker/apache.yml
+DOCKER_COMPOSE_YML = docker/test.yml
+DOCKER_IMAGE = php:7.3-apache
 
-.PHONY: build stop start clean dev_setup test test_debug
+.PHONY: build stop start clean dev_setup test test_debug test_unit_with_docker test_integration_with_docker
 
 build:
 	docker-compose -f $(DOCKER_COMPOSE_YML) build
@@ -22,5 +22,9 @@ dev_setup:
 test:
 	vendor/bin/phpunit
 
-test_debug:
-	vendor/bin/phpunit --debug
+# Before using these commands, make sure that dokcer is running with test.yml.
+test_unit_with_docker:
+	docker exec -it -w /opt/project apache /bin/bash -c "vendor/bin/phpunit"
+
+test_integration_with_docker:
+	docker exec -it -w /opt/project apache /bin/bash -c "vendor/bin/phpunit --configuration phpunit_integration.xml"

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
-# DOCKER_COMPOSE_YML = docker/apache.yml
-DOCKER_COMPOSE_YML = docker/test.yml
-DOCKER_IMAGE = php:7.3-apache
+DOCKER_COMPOSE_YML = docker/apache.yml
+# DOCKER_COMPOSE_YML = docker/test.yml
+# DOCKER_COMPOSE_YML = docker/wp_apache.yml
+DOCKER_IMAGE = php:7.4-apache
 
 .PHONY: build stop start clean dev_setup test test_debug test_unit_with_docker test_integration_with_docker
 

--- a/makefile
+++ b/makefile
@@ -23,7 +23,9 @@ dev_setup:
 test:
 	vendor/bin/phpunit
 
-# Before using these commands, make sure that dokcer is running with test.yml.
+start_test:
+	env DOCKER_IMAGE=${DOCKER_IMAGE} docker-compose -f docker/test.yml up
+
 test_unit_with_docker:
 	docker exec -it -w /opt/project apache /bin/bash -c "vendor/bin/phpunit"
 

--- a/test/helpers/TestUtils.php
+++ b/test/helpers/TestUtils.php
@@ -167,7 +167,6 @@ class TestUtils
     {
         $htaccess = file_get_contents($htaccessFilePath);
         $replacedHtaccess = $htaccess . "\nSetEnv WOVN_CONFIG " . $wovnConfigFilePath;
-        error_log($replacedHtaccess);
         file_put_contents($htaccessFilePath, $replacedHtaccess);
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-561

By this PR, you can set break point via XDebug.
You need to run tests inside docker, because of setup XDebug.

### Comments

### Release comments (new feature)
