### PR TITLE
Feature/add propper logging

### DIFF
--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -26,12 +26,17 @@ use \Wovnio\Wovnphp\CookieLang;
 list($store, $headers) = Utils::getStoreAndHeaders($_SERVER, $_COOKIE);
 
 if (!$store->isValid()) {
-    Logger::get()->error('WOVN Invalid configuration');
+    Logger::get()->critical('WOVN Invalid configuration');
     return false;
 }
 
 // Make it available for user application
 $_ENV['WOVN_TARGET_LANG'] = $headers->requestLang();
+
+Logger::get()->info('WOVN.php version ' . WOVN_PHP_VERSION . ' has received a request for '
+    . $_SERVER['REQUEST_URI'] . ' in ' . $_ENV['WOVN_TARGET_LANG'] . '.');
+Logger::get()->info('Request received. ' . print_r($_SERVER, true));
+
 $headers->requestOut();
 
 $uri = $headers->getDocumentURI();
@@ -39,7 +44,7 @@ if (!Utils::isIgnoredPath($uri, $store)) {
     $diagnostics = null;
     $benchmarkStart = 0;
     if (Utils::wovnDiagnosticsEnabled($store, $headers)) {
-        Logger::get()->info('WOVN DIAGNOSTICS IS ON');
+        Logger::get()->info('Wovn Diagnostics is turned on.');
         $benchmarkStart = microtime(true) * 1000;
         $diagnostics = new Diagnostics($store);
     }

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -53,6 +53,7 @@ if (!Utils::isIgnoredPath($uri, $store)) {
         if ($headers->shouldRedirect()) {
             // this carries an implied HTTP 302
             header("Location: " . $headers->computeRedirectUrl());
+            Logger::get()->info('Request ended, redirect: ' . $headers->computeRedirectUrl());
             exit();
         }
         $headers->responseOut();
@@ -70,10 +71,12 @@ if (!Utils::isIgnoredPath($uri, $store)) {
         if (Utils::wovnDiagnosticsEnabled($store, $headers)) {
             $benchmarkEnd = microtime(true) * 1000;
             $diagnostics->logPerformance($benchmarkStart, $benchmarkEnd);
+            Logger::get()->info('Request ended, swapping time (ms): ' . ($benchmarkEnd - $benchmarkStart));
             $diagnostics->logOriginalPage($buffer);
             $diagnostics->logSwappedPage($translatedBuffer);
             return $diagnostics->renderResults();
         } else {
+            Logger::get()->info('Request ended.');
             if ($translatedBuffer !== null && !empty($translatedBuffer)) {
                 Utils::changeHeaders($translatedBuffer, $store);
                 return $translatedBuffer;

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -35,7 +35,7 @@ $_ENV['WOVN_TARGET_LANG'] = $headers->requestLang();
 
 Logger::get()->info('WOVN.php version ' . WOVN_PHP_VERSION . ' has received a request for '
     . $_SERVER['REQUEST_URI'] . ' in ' . $_ENV['WOVN_TARGET_LANG'] . '.');
-Logger::get()->info('Request received. ' . $_SERVER);
+Logger::get()->info('Request received. ' . json_encode($_SERVER));
 
 $headers->requestOut();
 

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -35,7 +35,7 @@ $_ENV['WOVN_TARGET_LANG'] = $headers->requestLang();
 
 Logger::get()->info('WOVN.php version ' . WOVN_PHP_VERSION . ' has received a request for '
     . $_SERVER['REQUEST_URI'] . ' in ' . $_ENV['WOVN_TARGET_LANG'] . '.');
-Logger::get()->info('Request received. ' . print_r($_SERVER, true));
+Logger::get()->info('Request received. ' . $_SERVER);
 
 $headers->requestOut();
 

--- a/src/wovnio/utils/HTTPHeaderParser.php
+++ b/src/wovnio/utils/HTTPHeaderParser.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Wovnio\Utils\HTTPHeaderParser;
+
+
+class HTTPHeaderParser
+{
+    public static function parseRawHeader($rawHeader) {
+        if (!$rawHeader) {
+            return array();
+        }
+
+        $rawHeader = explode("\r\n", $rawHeader);
+        $parsedHeaders = array('status' => $rawHeader[0]);
+        foreach ($rawHeader as $value) {
+            $exploded = explode(':', $value, 2);
+            if (sizeof($exploded) == 2) {
+                $parsedHeaders[trim($exploded[0])] = trim($exploded[1]);
+            }
+        }
+        return $parsedHeaders;
+    }
+
+    public static function parseRawResponse($rawResponse, $headerSize) {
+        if (!$rawResponse || !$headerSize) {
+            return array();
+        }
+
+        $headers = substr($rawResponse, 0, $headerSize);
+        return self::parseRawHeader($headers);
+    }
+}

--- a/src/wovnio/utils/HTTPHeaderParser.php
+++ b/src/wovnio/utils/HTTPHeaderParser.php
@@ -3,10 +3,10 @@
 
 namespace Wovnio\Utils\HTTPHeaderParser;
 
-
 class HTTPHeaderParser
 {
-    public static function parseRawHeader($rawHeader) {
+    public static function parseRawHeader($rawHeader)
+    {
         if (!$rawHeader) {
             return array();
         }
@@ -22,7 +22,8 @@ class HTTPHeaderParser
         return $parsedHeaders;
     }
 
-    public static function parseRawResponse($rawResponse, $headerSize) {
+    public static function parseRawResponse($rawResponse, $headerSize)
+    {
         if (!$rawResponse || !$headerSize) {
             return array();
         }

--- a/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
@@ -35,7 +35,6 @@ abstract class AbstractRequestHandler
             switch ($method) {
                 case 'POST':
                     return $this->post($url, $headers, $query, $timeout);
-                    break;
             }
         } catch (\Exception $e) {
             $errorContext = array('method' => $method, 'url' => $url, 'exception' => $e);

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -50,7 +50,13 @@ class CurlRequestHandler extends AbstractRequestHandler
         $response = curl_exec($curl_session);
         $header_size = curl_getinfo($curl_session, CURLINFO_HEADER_SIZE);
         $headers = $response ? explode("\r\n", substr($response, 0, $header_size)) : array();
-
+        $parsedHeaders = array('status' => $headers[0]);
+        foreach ($headers as $value) {
+            $exploded = explode(':', $value, 2);
+            if (sizeof($exploded) == 2) {
+                $parsedHeaders[trim($exploded[0])] = trim($exploded[1]);
+            }
+        }
         if (curl_error($curl_session) !== '') {
             $curl_error_code = curl_errno($curl_session);
             $http_error_code = curl_getinfo($curl_session, CURLINFO_HTTP_CODE);
@@ -64,6 +70,6 @@ class CurlRequestHandler extends AbstractRequestHandler
 
         curl_close($curl_session);
 
-        return array($response_body, $headers, null);
+        return array($response_body, $parsedHeaders, null);
     }
 }

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -2,6 +2,7 @@
 namespace Wovnio\Utils\RequestHandlers;
 
 require_once 'AbstractRequestHandler.php';
+require_once DIRNAME(__FILE__) . '../../HTTPHeaderParser.php';
 
 use Wovnio\Utils\HTTPHeaderParser\HTTPHeaderParser;
 use Wovnio\Utils\RequestHandlers\AbstractRequestHandler;

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -3,6 +3,7 @@ namespace Wovnio\Utils\RequestHandlers;
 
 require_once 'AbstractRequestHandler.php';
 
+use Wovnio\Utils\HTTPHeaderParser\HTTPHeaderParser;
 use Wovnio\Utils\RequestHandlers\AbstractRequestHandler;
 
 class CurlRequestHandler extends AbstractRequestHandler
@@ -50,13 +51,7 @@ class CurlRequestHandler extends AbstractRequestHandler
         $response = curl_exec($curl_session);
         $header_size = curl_getinfo($curl_session, CURLINFO_HEADER_SIZE);
         $headers = $response ? explode("\r\n", substr($response, 0, $header_size)) : array();
-        $parsedHeaders = array('status' => $headers[0]);
-        foreach ($headers as $value) {
-            $exploded = explode(':', $value, 2);
-            if (sizeof($exploded) == 2) {
-                $parsedHeaders[trim($exploded[0])] = trim($exploded[1]);
-            }
-        }
+        $parsedHeaders = HTTPHeaderParser::parseRawHeader(substr($response, 0, $header_size));
         if (curl_error($curl_session) !== '') {
             $curl_error_code = curl_errno($curl_session);
             $http_error_code = curl_getinfo($curl_session, CURLINFO_HTTP_CODE);

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -52,7 +52,7 @@ class CurlRequestHandler extends AbstractRequestHandler
         $response = curl_exec($curl_session);
         $header_size = curl_getinfo($curl_session, CURLINFO_HEADER_SIZE);
         $headers = $response ? explode("\r\n", substr($response, 0, $header_size)) : array();
-        $parsedHeaders = HTTPHeaderParser::parseRawHeader(substr($response, 0, $header_size));
+        $parsedHeaders = HTTPHeaderParser::parseRawResponse($response, $header_size);
         if (curl_error($curl_session) !== '') {
             $curl_error_code = curl_errno($curl_session);
             $http_error_code = curl_getinfo($curl_session, CURLINFO_HTTP_CODE);

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -77,7 +77,7 @@ class API
             $status = $headers['status'];
             $data['body'] = "[Hidden]";
             Logger::get()->info("[{$requestUUID}] API call to html-swapper finished: {$status}.");
-            Logger::get()->info("[{$requestUUID}] API call payload: " . print_r($data, true));
+            Logger::get()->info("[{$requestUUID}] API call payload: " . $data);
             if ($response === null) {
                 if ($error) {
                     header("X-Wovn-Error: $error");

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -73,9 +73,15 @@ class API
                 return $marker->revert($converted_html);
             }
             list($response, $headers, $error) = $request_handler->sendRequest('POST', $api_url, $data, $timeout);
+            $requestUUID = $headers['X-Request-Id'];
+            $status = $headers['status'];
+            $data['body'] = "[Hidden]";
+            Logger::get()->info("[{$requestUUID}] API call to html-swapper finished: {$status}.");
+            Logger::get()->info("[{$requestUUID}] API call payload: " . print_r($data, true));
             if ($response === null) {
                 if ($error) {
                     header("X-Wovn-Error: $error");
+                    Logger::get()->error("[{$requestUUID}] API call error: {$error}.");
                 }
                 return $marker->revert($converted_html);
             }

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -80,7 +80,7 @@ class API
                 $status = array_key_exists('status', $headers) ? $headers['status'] : 'STATUS_UNKNOWN';
                 $data['body'] = "[Hidden]";
                 Logger::get()->info("[{$requestUUID}] API call to html-swapper finished: {$status}.");
-                Logger::get()->info("[{$requestUUID}] API call payload: " . $data);
+                Logger::get()->info("[{$requestUUID}] API call payload: " . json_encode($data));
             }
 
             if ($response === null) {

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -73,11 +73,16 @@ class API
                 return $marker->revert($converted_html);
             }
             list($response, $headers, $error) = $request_handler->sendRequest('POST', $api_url, $data, $timeout);
-            $requestUUID = $headers['X-Request-Id'];
-            $status = $headers['status'];
-            $data['body'] = "[Hidden]";
-            Logger::get()->info("[{$requestUUID}] API call to html-swapper finished: {$status}.");
-            Logger::get()->info("[{$requestUUID}] API call payload: " . $data);
+
+            $requestUUID = 'NO_UUID';
+            if ($headers) {
+                $requestUUID = array_key_exists('X-Request-Id', $headers) ? $headers['X-Request-Id'] : 'NO_UUID';
+                $status = array_key_exists('status', $headers) ? $headers['status'] : 'STATUS_UNKNOWN';
+                $data['body'] = "[Hidden]";
+                Logger::get()->info("[{$requestUUID}] API call to html-swapper finished: {$status}.");
+                Logger::get()->info("[{$requestUUID}] API call payload: " . $data);
+            }
+
             if ($response === null) {
                 if ($error) {
                     header("X-Wovn-Error: $error");

--- a/src/wovnio/wovnphp/Diagnostics.php
+++ b/src/wovnio/wovnphp/Diagnostics.php
@@ -58,6 +58,7 @@ class Diagnostics
         $buffer = '<html wovn-ignore><body style="margin-left:20px;"><h1>WOVN.php Diagnostics Page</h1>';
         if (!$this->authenticate($_COOKIE["wovn_diagnostics_name"], $_COOKIE["wovn_diagnostics_hash"])) {
             $buffer .= '<p>You are not authorized to view this page.</p>';
+            Logger::get()->info('Wovn Diagnostics is not displayed because user is not authorized.');
             return $buffer;
         }
         foreach ($this->results as $item => $result) {

--- a/src/wovnio/wovnphp/Logger.php
+++ b/src/wovnio/wovnphp/Logger.php
@@ -35,6 +35,7 @@ class Logger
 
     public function __construct($quiet = false, $prefix = 'WOVN.php')
     {
+        date_default_timezone_set('UTC');
         $this->prefix = $prefix;
         $this->quiet = $quiet;
         $this->destinationType = self::PHP_SYSTEM_LOGGER;

--- a/src/wovnio/wovnphp/Logger.php
+++ b/src/wovnio/wovnphp/Logger.php
@@ -40,12 +40,14 @@ class Logger
         $this->destinationType = self::PHP_SYSTEM_LOGGER;
     }
 
-    public function setLogFilePath($logFilePath) {
+    public function setLogFilePath($logFilePath)
+    {
         $this->logFilePath = $logFilePath;
         $this->destinationType = self::LOG_FILE;
     }
 
-    public function setMaxLogLineLength($maxLength) {
+    public function setMaxLogLineLength($maxLength)
+    {
         $this->maxLogLineLength = $maxLength;
     }
 
@@ -145,7 +147,8 @@ class Logger
         return strtr($message, $replacements);
     }
 
-    private function truncateToLengthLimit($log) {
+    private function truncateToLengthLimit($log)
+    {
         if (strlen($log) < $this->maxLogLineLength) {
             return $log;
         }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -31,7 +31,7 @@ class Store
         if (file_exists($settingFileName)) {
             $userSettings = parse_ini_file($settingFileName, true);
         } else {
-            Logger::get()->warning('WOVN Configuration not found: {filename}.', array('filename' => $settingFileName));
+            Logger::get()->critical('WOVN Configuration not found: {filename}.', array('filename' => $settingFileName));
             $userSettings = null;
         }
 
@@ -187,6 +187,16 @@ class Store
         // Use default timeout if not set
         if ($this->settings['api_timeout'] === '') {
             $this->settings['api_timeout'] = $defaultSettings['api_timeout'];
+        }
+
+        // Configure WOVN logging
+        if (!empty($this->settings['logging'])) {
+            if ($this->settings['logging']['destination'] == 'file') {
+                Logger::get()->setLogFilePath($this->settings['logging']['path']);
+            }
+            if (!empty($this->settings['logging']['max_line_length'])) {
+                Logger::get()->setMaxLogLineLength($this->settings['logging']['max_line_length']);
+            }
         }
 
         $this->configLoaded = true;


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-563

### Comments
To turn on WOVN logging, the user must add the following to `wovn.json` config:
```
"logging": {
        "destination": "file",
        "path": "/Users/zeyuwu/Sites/logs/wovnphplog.log",
        "max_line_length": 5124
        }
```
`destination`: string, can be either `file` (custom log file) or `default` (standard PHP logging). When `file` is used, `path` must also be set.
`path`: string, the fully qualified path to the custom log file. The file doesn't have to exist, but the current user must have write permission to the path.
`max_line_length`: integer, this should be the same as `php.ini`'s `log_errors_max_len`. When a log message exceeds this length, the message will be truncated and suffixed with `[TRUNCATED]`.

#### What's logged

When logging the request to html-swapper, the request UUID is logged. This is the same UUID used inside html-swapper.

### Release comments (new feature)
Sample Log
```
WOVN.php [2020-11-18 06:50:15][INFO] WOVN.php version 1.5.1 has received a request for /fr/product.php in fr.
WOVN.php [2020-11-18 06:50:15][INFO] Request received. Array
(
    [REDIRECT_WOVN_CONFIG] => 
    [REDIRECT_STATUS] => 200
    [WOVN_CONFIG] => 
    [HTTP_HOST] => testsite.com
    [HTTP_CONNECTION] => keep-alive
    [HTTP_UPGRADE_INSECURE_REQUESTS] => 1
    [HTTP_USER_AGENT] => Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36
    [HTTP_ACCEPT] => text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
    [HTTP_ACCEPT_ENCODING] => gzip, deflate
    [HTTP_ACCEPT_LANGUAGE] => en-US,en;q=0.9
    [HTTP_COOKIE] => wovn_selected_lang=ja
    [PATH] => /usr/bin:/bin:/usr/sbin:/sbin
    [SERVER_SIGNATURE] => 
    [SERVER_SOFTWARE] => Apache/2.4.41 (Unix) PHP/7.3.11
    [SERVER_NAME] => testsite.com
    [SERVER_ADDR] => 127.0.0.1
    [SERVER_PORT] => 80
    [REMOTE_ADDR] => 127.0.0.1
    [DOCUMENT_ROOT] => /Users/zeyuwu/Sites
    [REQUEST_SCHEME] => http
    [CONTEXT_PREFIX] => 
    [CONTEXT_DOCUMENT_ROOT] => /Users/zeyuwu/Sites
    [SERVER_ADMIN] => you@example.com
    [SCRIPT_FILENAME] => /Users/zeyuwu/Sites/wovn_index.php
    [REMOTE_PORT] => 55403
    [REDIRECT_URL] => /fr/product.php
    [GATEWAY_INTERFACE] => CGI/1.1
    [SERVER_PROTOCOL] => HTTP/1.1
    [REQUEST_METHOD] => GET
    [QUERY_STRING] => 
    [REQUEST_URI] => /fr/product.php
    [SCRIPT_NAME] => /wovn_index.php
    [PHP_SELF] => /wovn_index.php
    [REQUEST_TIME_FLOAT] => 1605682215.843
    [REQUEST_TIME] => 1605682215
)

WOVN.php [2020-11-18 06:50:15][INFO] [8c91634b-da92-446c-aaa2-ae389944934d] API call to html-swapper finished: HTTP/1.1 500 Internal Server Error .
WOVN.php [2020-11-18 06:50:15][INFO] [8c91634b-da92-446c-aaa2-ae389944934d] API call payload: Array
(
    [url] => http://testsite.com/en/product.php
    [token] => cKyn2t
    [lang_code] => fr
    [url_pattern] => custom_domain
    [lang_param_name] => wovn
    [product] => WOVN.php
    [version] => 1.5.1
    [body] => [Hidden]
    [custom_domain_langs] => {"testsite.com\/ja":"ja","testsite.com\/fr":"fr","testsite.com\/en":"en","testsite.com\/zh-CHS":"zh-CHS"}
)

WOVN.php [2020-11-18 06:50:15][INFO] Request ended.

```