### PR TITLE
Add insert_hreflangs feature

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -21,6 +21,9 @@
     <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
 
     <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
+
+    <!-- TODO: src/wovnio/html/HtmlConverter.php is using function name started with underscore -->
+    <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
   </rule>
 
   <!-- use camelCase everywhere (PSR2 forces it for class members only) -->

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -6,6 +6,7 @@
 
   <file>./</file>
   <exclude-pattern>./vendor</exclude-pattern>
+  <exclude-pattern>./docker</exclude-pattern>
   <exclude-pattern>./src/wovnio/modified_vendor</exclude-pattern>
 
   <rule ref="Internal.Tokenizer.Exception">

--- a/README.en.md
+++ b/README.en.md
@@ -341,6 +341,7 @@ and should be used for performance optimization.
 | [check_amp](#check_amp)                                      | all                       | Enable/Disable translation for AMP pages                     |
 | [site_prefix_path](#site_prefix_path)                        | path                      | Changes where the language code is inserted                  |
 | [custom_domain_langs](#custom_domain_langs)                  | custom_domain             | Use custom domains for supported languages                   |
+| [insert_hreflangs](#custom_domain_langs)                     | all                       | Enable/disable addition of link tag with hreflang attribute  |
 
 #### `lang_param_name`
 This parameter is only valid for when `url_pattern_name = query`.
@@ -691,6 +692,27 @@ site_prefix_path = dir1/dir2
 ```json
 {
   "site_prefix_path": "dir1/dir2"
+}
+```
+
+#### `insert_hreflangs`
+
+This parameter tells WOVN.php to insert link tag with hreflang.
+If setting is on, the tag like `<link rel="alternate" hreflang="en" href="https://my-website.com/en/">` will be inserted for published languages.
+
+If setting is off, WOVN.php doesn't add any change to link tag with hreflang.
+
+`wovn.ini`
+
+```
+insert_hreflangs = 1
+```
+
+`wovn.json`
+
+```json
+{
+  "insert_hreflangs": true
 }
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -356,6 +356,7 @@ NOT SUPPORTED
 | [check_amp](#check_amp)              | all                            | AMPページを翻訳対象にするかどうかを設定 |
 | [site_prefix_path](#site_prefix_path)| path                           | 言語コードの挿入位置を変更            |
 | [custom_domain_langs](#custom_domain_langs)| custom_domain            | サポートされている言語のドメインとパスを定義 |
+| [insert_hreflangs](#custom_domain_langs)| all                         | hreflang属性を持つlinkタグの挿入要否を設定 |
 
 
 #### `lang_param_name`
@@ -697,6 +698,25 @@ site_prefix_path = dir1/dir2
 }
 ```
 
+#### `insert_hreflangs`
+このパラメータはhreflang属性を持つlinkタグを挿入するかどうかを指定します。  
+例えば設定が有効の場合、`<link rel="alternate" hreflang="en" href="https://my-website.com/en/">`のように、公開されている言語のタグを挿入します。
+
+設定が無効の場合はタグは挿入せず、元からあるhreflang属性を持ったタグに変更は加えません。
+
+`wovn.ini`
+
+```
+insert_hreflangs = 1
+```
+
+`wovn.json`
+
+```json
+{
+  "insert_hreflangs": true
+}
+```
 
 ## 4. 環境変数
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ DOCKER_COMPOSE_YML = docker/apache.yml
 # DOCKER_COMPOSE_YML = docker/wp_apache.yml
 DOCKER_IMAGE = php:7.4-apache
 
-.PHONY: build stop start clean dev_setup test test_debug test_unit_with_docker test_integration_with_docker
+.PHONY: build stop start clean dev_setup test test_debug lint_with_docker test_unit_with_docker test_integration_with_docker
 
 build:
 	docker-compose -f $(DOCKER_COMPOSE_YML) build
@@ -25,6 +25,9 @@ test:
 
 start_test:
 	env DOCKER_IMAGE=${DOCKER_IMAGE} docker-compose -f docker/test.yml up
+
+lint_with_docker:
+	docker exec -it -w /opt/project apache /bin/bash -c "vendor/bin/phpcs"
 
 test_unit_with_docker:
 	docker exec -it -w /opt/project apache /bin/bash -c "vendor/bin/phpunit"

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.6.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.6.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.5.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.6.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -108,11 +108,11 @@ class HtmlConverter
             } elseif (strtolower($node->tag) == "body") {
                 $body = $node;
             }
-            $self->_removeWovnIgnore($node, $marker);
-            $self->_removeCustomIgnoreClass($node, $marker);
-            $self->_removeForm($node, $marker);
+            $self->removeWovnIgnore($node, $marker);
+            $self->removeCustomIgnoreClass($node, $marker);
+            $self->removeForm($node, $marker);
             // inside <script>, comment("<!--") is invalid
-            $self->_removeScript($node, $marker);
+            $self->removeScript($node, $marker);
         });
     }
 

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -108,11 +108,11 @@ class HtmlConverter
             } elseif (strtolower($node->tag) == "body") {
                 $body = $node;
             }
-            $self->removeWovnIgnore($node, $marker);
-            $self->removeCustomIgnoreClass($node, $marker);
-            $self->removeForm($node, $marker);
+            $self->_removeWovnIgnore($node, $marker);
+            $self->_removeCustomIgnoreClass($node, $marker);
+            $self->_removeForm($node, $marker);
             // inside <script>, comment("<!--") is invalid
-            $self->removeScript($node, $marker);
+            $self->_removeScript($node, $marker);
         });
     }
 
@@ -298,19 +298,22 @@ class HtmlConverter
         $key = $marker->addCommentValue($originalText);
         $element->innertext = $key;
     }
-    
+
     /**
+     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
+     * Use `_` prefix to imply `private`
+     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    private function removeWovnIgnore($node, $marker)
+    public function _removeWovnIgnore($node, $marker)
     {
         if ($node->hasAttribute('wovn-ignore') || $node->hasAttribute('data-wovn-ignore')) {
             $this->putReplaceMarker($node, $marker);
         }
     }
 
-    private function removeCustomIgnoreClass($node, $marker)
+    public function _removeCustomIgnoreClass($node, $marker)
     {
         $class_attr = $node->getAttribute('class');
         if ($class_attr) {
@@ -326,10 +329,13 @@ class HtmlConverter
     /**
      * Remove form elements to avoid CSRF token or flexible input's value
      *
+     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
+     * Use `_` prefix to imply `private`
+     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    private function removeForm($node, $marker)
+    public function _removeForm($node, $marker)
     {
         if (strtolower($node->tag) === 'form') {
             $this->putReplaceMarker($node, $marker);
@@ -351,10 +357,13 @@ class HtmlConverter
      * Remove <script>
      * some script have random value for almost same purpose with CSRF
      *
+     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
+     * Use `_` prefix to imply `private`
+     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    private function removeScript($node, $marker)
+    public function _removeScript($node, $marker)
     {
         if (strtolower($node->tag) === 'script' && !preg_match('/type=["\']application\/ld\+json["\']/', $node->attribute)) {
             $this->putReplaceMarker($node, $marker);

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -45,7 +45,9 @@ class HtmlConverter
     public function insertSnippetAndHreflangTags($adds_backend_error_mark)
     {
         $this->html = $this->insertSnippet($this->html, $adds_backend_error_mark);
-        $this->html = $this->insertHreflangTags($this->html);
+        if ($this->store->settings['insert_hreflangs']) {
+            $this->html = $this->insertHreflangTags($this->html);
+        }
 
         if ($this->isNoindexLang($this->headers->requestLang())) {
             $this->html = $this->insertNoindex($this->html);

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -18,11 +18,11 @@ class HtmlConverter
 {
     public static $supportedEncodings = array('UTF-8', 'EUC-JP', 'SJIS', 'eucJP-win', 'SJIS-win', 'JIS', 'ISO-2022-JP', 'ASCII');
 
-    private $html;
     private $encoding;
     private $token;
     private $store;
     private $headers;
+    private $marker;
 
 
     /**
@@ -33,28 +33,26 @@ class HtmlConverter
      * @param Store $store
      * @param Headers $headers
      */
-    public function __construct($html, $encoding, $token, $store, $headers)
+    public function __construct($encoding, $token, $store, $headers)
     {
-        $this->html = $html;
         $this->encoding = $encoding;
         $this->token = $token;
         $this->store = $store;
         $this->headers = $headers;
+        $this->marker = new HtmlReplaceMarker();
     }
 
-    public function insertSnippetAndHreflangTags($adds_backend_error_mark)
+    public function insertSnippetAndHreflangTags($html, $add_fallback_mark)
     {
-        $this->html = $this->insertSnippet($this->html, $adds_backend_error_mark);
+        $converted_html = $html;
+        $converted_html = $this->insertSnippet($converted_html, $add_fallback_mark);
         if ($this->store->settings['insert_hreflangs']) {
-            $this->html = $this->insertHreflangTags($this->html);
+            $converted_html = $this->insertHreflangTags($converted_html);
         }
-
         if ($this->isNoindexLang($this->headers->requestLang())) {
-            $this->html = $this->insertNoindex($this->html);
+            $converted_html = $this->insertNoindex($converted_html);
         }
-
-        $marker = new HtmlReplaceMarker();
-        return array($this->html, $marker);
+        return $converted_html;
     }
 
     /**
@@ -63,23 +61,22 @@ class HtmlConverter
      *
      * @return array converted html and HtmlReplaceMarker
      */
-    public function convertToAppropriateBodyForApi()
+    public function convertToAppropriateBodyForApi($html)
     {
         if ($this->encoding && in_array($this->encoding, self::$supportedEncodings)) {
             $encoding = $this->encoding;
         } else {
             // Encoding detection uses 30% of execution time for this method.
-            $encoding = mb_detect_encoding($this->html, self::$supportedEncodings);
+            $encoding = mb_detect_encoding($html, self::$supportedEncodings);
         }
-        $marker = new HtmlReplaceMarker();
-        $converted_html = $this->html;
+        $converted_html = $html;
 
-        $dom = SimpleHtmlDom::str_get_html($this->html, $encoding, false, false, $encoding, false);
+        $dom = SimpleHtmlDom::str_get_html($converted_html, $encoding, false, false, $encoding, false);
         if ($dom) {
-            $this->replaceDom($dom, $marker);
+            $this->replaceDom($dom, $this->marker);
 
             $converted_html = $dom->save();
-            $converted_html = $this->removeBackendWovnIgnoreComment($converted_html, $marker);
+            $converted_html = $this->removeBackendWovnIgnoreComment($converted_html, $this->marker);
 
             // Without clear(), Segmentation fault will be raised.
             // @see https://sourceforge.net/p/simplehtmldom/bugs/103/
@@ -87,7 +84,13 @@ class HtmlConverter
             unset($dom);
         }
 
-        return array($converted_html, $marker);
+        return $converted_html;
+    }
+
+    public function revertMarkers($marked_html)
+    {
+        $unmarked_html = $this->marker->revert($marked_html);
+        return $unmarked_html;
     }
 
     private function replaceDom($dom, &$marker)
@@ -107,36 +110,12 @@ class HtmlConverter
             } elseif (strtolower($node->tag) == "body") {
                 $body = $node;
             }
-            $self->_removeSnippet($node);
-            if ($adds_hreflang) {
-                $self->_removeHreflang($node);
-            }
             $self->_removeWovnIgnore($node, $marker);
             $self->_removeCustomIgnoreClass($node, $marker);
             $self->_removeForm($node, $marker);
             // inside <script>, comment("<!--") is invalid
             $self->_removeScript($node, $marker);
         });
-
-        $tags = array($head, $body, $html);
-        foreach ($tags as $insert_tag) {
-            if (is_null($insert_tag)) {
-                continue;
-            }
-
-            $hreflangTags = array();
-            if ($adds_hreflang) {
-                $lang_codes = $this->store->settings['supported_langs'];
-                foreach ($lang_codes as $lang_code) {
-                    $href = $this->buildHrefLang($lang_code);
-                    array_push($hreflangTags, '<link rel="alternate" hreflang="' . Lang::iso6391Normalization($lang_code) . '" href="' . $href . '">');
-                }
-            }
-
-            $snippet = $this->buildSnippetCode(true);
-            $insert_tag->innertext = implode('', $hreflangTags) . $snippet . $insert_tag->innertext;
-            break;
-        }
     }
 
     /**
@@ -144,14 +123,14 @@ class HtmlConverter
      * When snippet is always inserted, do nothing
      *
      * @param string $html
-     * @param bool $adds_backend_error_mark
+     * @param bool $add_fallback_mark
      */
-    private function insertSnippet($html, $adds_backend_error_mark)
+    private function insertSnippet($html, $add_fallback_mark)
     {
         $snippet_regex = "/<script[^>]*src=[^>]*j\.[^ '\">]*wovn\.io[^>]*><\/script>/i";
         $html = $this->removeTagFromHtmlByRegex($html, $snippet_regex);
 
-        $snippet_code = $this->buildSnippetCode($adds_backend_error_mark);
+        $snippet_code = $this->buildSnippetCode($add_fallback_mark);
         $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
         return $this->insertAfterTag($parent_tags, $html, $snippet_code);
@@ -192,7 +171,7 @@ class HtmlConverter
         return $result;
     }
 
-    private function buildSnippetCode($adds_backend_error_mark)
+    private function buildSnippetCode($add_fallback_mark)
     {
         $data_wovnio_params = array();
         $data_wovnio_params['key'] = $this->token;
@@ -217,7 +196,7 @@ class HtmlConverter
         $widget_url = $this->store->settings['widget_url'];
         $data_wovnio = htmlentities($this->buildParamsStr($data_wovnio_params));
         $data_wovnio_info = htmlentities($this->buildParamsStr($data_wovnio_info_params));
-        $fallback_mark = $adds_backend_error_mark ? ' data-wovnio-type="fallback_snippet"' : '';
+        $fallback_mark = $add_fallback_mark ? ' data-wovnio-type="fallback_snippet"' : '';
 
         return "<script src=\"$widget_url\" data-wovnio=\"$data_wovnio\" data-wovnio-info=\"$data_wovnio_info\"$fallback_mark async></script>";
     }
@@ -239,6 +218,9 @@ class HtmlConverter
      */
     private function insertHreflangTags($html)
     {
+        if (!$this->store->settings['insert_hreflangs']) {
+            return;
+        }
         if (isset($this->store->settings['supported_langs'])) {
             if (is_array($this->store->settings['supported_langs'])) {
                 $lang_codes = $this->store->settings['supported_langs'];

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -96,13 +96,11 @@ class HtmlConverter
     private function replaceDom($dom, &$marker)
     {
         $self = $this;
-        $adds_hreflang = isset($this->store) && isset($this->headers);
-
         $html = null;
         $head = null;
         $body = null;
 
-        $dom->iterateAll(function ($node) use (&$self, $marker, $adds_hreflang, &$html, &$head, &$body) {
+        $dom->iterateAll(function ($node) use (&$self, $marker, &$html, &$head, &$body) {
             if (strtolower($node->tag) == "html") {
                 $html = $node;
             } elseif (strtolower($node->tag) == "head") {
@@ -299,46 +297,6 @@ class HtmlConverter
 
         $key = $marker->addCommentValue($originalText);
         $element->innertext = $key;
-    }
-
-    // PHP 5.3 doesn't allow calling private method inside anonymous functions,
-    // so we use '_' for implicit visibility in the methods below
-    // phpcs:disable Squiz.Scope.MethodScope.Missing
-    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
-
-    /**
-     * @param SimpleHtmlDomNode $node
-     */
-    function _removeSnippet($node)
-    {
-        if (strtolower($node->tag) !== 'script') {
-            return;
-        }
-
-        $src_value = $node->getAttribute('src');
-        if (strpos($src_value, '//j.wovn.io/') !== false ||
-            strpos($src_value, '//j.dev-wovn.io:3000/') !== false) {
-            $node->outertext = ''; // remove node
-        }
-    }
-
-    /**
-     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
-     * Use `_` prefix to imply `private`
-     *
-     * @param SimpleHtmlDomNode $node
-     */
-    function _removeHreflang($node)
-    {
-        if (strtolower($node->tag) != 'link') {
-            return;
-        }
-
-        $lang_codes = $this->store->settings['supported_langs'];
-        $hreflangValue = $node->getAttribute('hreflang');
-        if (in_array(Lang::getCode($hreflangValue), $lang_codes)) {
-            $node->outertext = ''; // remove node
-        }
     }
 
     /**

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -298,22 +298,19 @@ class HtmlConverter
         $key = $marker->addCommentValue($originalText);
         $element->innertext = $key;
     }
-
+    
     /**
-     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
-     * Use `_` prefix to imply `private`
-     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    function _removeWovnIgnore($node, $marker)
+    private function removeWovnIgnore($node, $marker)
     {
         if ($node->hasAttribute('wovn-ignore') || $node->hasAttribute('data-wovn-ignore')) {
             $this->putReplaceMarker($node, $marker);
         }
     }
 
-    function _removeCustomIgnoreClass($node, $marker)
+    private function removeCustomIgnoreClass($node, $marker)
     {
         $class_attr = $node->getAttribute('class');
         if ($class_attr) {
@@ -329,13 +326,10 @@ class HtmlConverter
     /**
      * Remove form elements to avoid CSRF token or flexible input's value
      *
-     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
-     * Use `_` prefix to imply `private`
-     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    function _removeForm($node, $marker)
+    private function removeForm($node, $marker)
     {
         if (strtolower($node->tag) === 'form') {
             $this->putReplaceMarker($node, $marker);
@@ -357,13 +351,10 @@ class HtmlConverter
      * Remove <script>
      * some script have random value for almost same purpose with CSRF
      *
-     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
-     * Use `_` prefix to imply `private`
-     *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
      */
-    function _removeScript($node, $marker)
+    private function removeScript($node, $marker)
     {
         if (strtolower($node->tag) === 'script' && !preg_match('/type=["\']application\/ld\+json["\']/', $node->attribute)) {
             $this->putReplaceMarker($node, $marker);

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -49,6 +49,7 @@ class API
             'lang_code' => $headers->requestLang(),
             'url_pattern' => $store->settings['url_pattern_name'],
             'lang_param_name' => $store->settings['lang_param_name'],
+            'insert_hreflangs' => $store->settings['insert_hreflangs'],
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_html

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -49,7 +49,6 @@ class API
             'lang_code' => $headers->requestLang(),
             'url_pattern' => $store->settings['url_pattern_name'],
             'lang_param_name' => $store->settings['lang_param_name'],
-            'insert_hreflangs' => $store->settings['insert_hreflangs'],
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_html
@@ -63,6 +62,9 @@ class API
         }
         if (!empty($store->settings['site_prefix_path'])) {
             $data['site_prefix_path'] = $store->settings['site_prefix_path'];
+        }
+        if (isset($store->settings['insert_hreflangs'])) {
+            $data['insert_hreflangs'] = json_encode($store->settings['insert_hreflangs']);
         }
         if ($store->getCustomDomainLangs()) {
             $data['custom_domain_langs'] = json_encode($store->getCustomDomainLangs()->toHtmlSwapperHash());

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -28,18 +28,18 @@ class API
         $encoding = $store->settings['encoding'];
         $token = $store->settings['project_token'];
 
-        $converter = new HtmlConverter($original_content, $encoding, $token, $store, $headers);
+        $converter = new HtmlConverter($encoding, $token, $store, $headers);
         if (self::makeAPICall($store, $headers) === false) {
-            list($translated_content) = $converter->insertSnippetAndHreflangTags(false);
+            $translated_content = $converter->insertSnippetAndHreflangTags($original_content, false);
             return $translated_content;
         }
 
         $saves_memory = $store->settings['save_memory_by_sending_wovn_ignore_content'];
-        if ($saves_memory) {
-            list($converted_html, $marker) = $converter->insertSnippetAndHreflangTags(true);
-        } else {
-            list($converted_html, $marker) = $converter->convertToAppropriateBodyForApi();
+        $converted_html = $original_content;
+        if (!$saves_memory) {
+            $converted_html = $converter->convertToAppropriateBodyForApi($converted_html);
         }
+        $converted_html = $converter->insertSnippetAndHreflangTags($converted_html, true);
 
         $timeout = $store->settings['api_timeout'];
         $computedUrl = self::getUriRepresentation($headers->urlKeepTrailingSlash, $store, $headers->requestLang());
@@ -91,19 +91,19 @@ class API
                     header("X-Wovn-Error: $error");
                     Logger::get()->error("[{$requestUUID}] API call error: {$error}.");
                 }
-                return $marker->revert($converted_html);
+                return $converter->revertMarkers($converted_html);
             }
 
             $translation_response = json_decode($response, true);
             if (array_key_exists('body', $translation_response)) {
-                return $marker->revert($translation_response['body']);
+                return $converter->revertMarkers($translation_response['body']);
             } else {
-                return $marker->revert($converted_html);
+                return $converter->revertMarkers($converted_html);
             }
         } catch (\Exception $e) {
             Logger::get()->error('Failed to get translated content: {exception}.', array('exception' => $e));
 
-            return $marker->revert($converted_html);
+            return $converter->revertMarkers($converted_html);
         }
     }
 

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -98,6 +98,7 @@ class Store
             'ignore_regex' => array(),
             'ignore_class' => array(),
             'no_index_langs' => array(),
+            'insert_hreflangs' => true,
             'site_prefix_path' => null,
             'custom_domain_langs' => array(),
 

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -34,7 +34,6 @@ class Store
             Logger::get()->critical('WOVN Configuration not found: {filename}.', array('filename' => $settingFileName));
             $userSettings = null;
         }
-
         return new Store($userSettings);
     }
 
@@ -198,6 +197,10 @@ class Store
             if (!empty($this->settings['logging']['max_line_length'])) {
                 Logger::get()->setMaxLogLineLength($this->settings['logging']['max_line_length']);
             }
+        }
+
+        if (!is_bool($this->settings['insert_hreflangs'])) {
+            $this->settings['insert_hreflangs'] = !!$this->settings['insert_hreflangs'];
         }
 
         $this->configLoaded = true;

--- a/test/integration/InsertHreflangsTest.php
+++ b/test/integration/InsertHreflangsTest.php
@@ -1,0 +1,98 @@
+<?php
+namespace Wovnio\Wovnphp\Tests\Integration;
+
+require_once(__DIR__ . '/../helpers/TestUtils.php');
+use Wovnio\Test\Helpers\TestUtils;
+
+class InsertHreflangsTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');
+        $this->docRoot    = '/var/www/html';
+
+        TestUtils::cleanUpDirectory($this->docRoot);
+
+        // Copy WOVN.php
+        mkdir("{$this->docRoot}/WOVN.php");
+        exec("cp -rf {$this->sourceDir}/src {$this->docRoot}/WOVN.php/src");
+        copy("{$this->sourceDir}/htaccess_sample", "{$this->docRoot}/.htaccess");
+
+        // Set html-swapper mock
+        mkdir("{$this->docRoot}/v0");
+        copy("{$this->sourceDir}/test/fixtures/integration/v0/translation", "{$this->docRoot}/v0/translation");
+    }
+
+    protected function tearDown()
+    {
+        TestUtils::cleanUpDirectory($this->docRoot);
+    }
+
+    public function testInsertHreflangsTrue()
+    {
+        $langs = array('en', 'ja', 'en-US', 'zh-Hant-HK');
+        copy("{$this->sourceDir}/wovn_index_sample.php", "{$this->docRoot}/wovn_index.php");
+        $original_html = '<html>'.
+        '<head>'.
+        '<link rel="alternate" hreflang="fr" href="http://localhost/fr/index.html">'.
+        '</head>'.
+        '<body>test</body>'.
+        '</html>';
+        TestUtils::writeFile("{$this->docRoot}/index.html", $original_html);
+        TestUtils::setWovnIni("{$this->docRoot}/wovn.ini", array(
+            'url_pattern_name' => 'path',
+            'supported_langs' => $langs,
+            'insert_hreflangs' => true
+        ));
+
+        $content_without_html_swapper = '<html>'.
+        '<head>'.
+        '<link rel="alternate" hreflang="en" href="http://localhost/index.html">'.
+        '<link rel="alternate" hreflang="ja" href="http://localhost/ja/index.html">'.
+        '<link rel="alternate" hreflang="en-US" href="http://localhost/en-US/index.html">'.
+        '<link rel="alternate" hreflang="zh-Hant-HK" href="http://localhost/zh-Hant-HK/index.html">'.
+        '<script src="//j.wovn.io/1" '.
+        'data-wovnio="key=TOKEN&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases=[]&amp;langParamName=wovn" '.
+        'data-wovnio-info="version=WOVN.php_VERSION" '.
+        'async></script>'.
+        '<link rel="alternate" hreflang="fr" href="http://localhost/fr/index.html">'.
+        '</head>'.
+        '<body>test</body>'.
+        '</html>';
+
+        $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/index.html')->body);
+        $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/en/index.html')->body);
+    }
+
+    public function testInsertHreflangsFalse()
+    {
+        $langs = array('en', 'ja', 'en-US', 'zh-Hant-HK');
+        copy("{$this->sourceDir}/wovn_index_sample.php", "{$this->docRoot}/wovn_index.php");
+        $original_html = '<html>'.
+        '<head>'.
+        '<link rel="alternate" hreflang="fr" href="http://localhost/fr/index.html">'.
+        '</head>'.
+        '<body>test</body>'.
+        '</html>';
+        TestUtils::writeFile("{$this->docRoot}/index.html", $original_html);
+        TestUtils::setWovnIni("{$this->docRoot}/wovn.ini", array(
+            'url_pattern_name' => 'path',
+            'supported_langs' => $langs,
+            'insert_hreflangs' => false
+        ));
+
+        $content_without_html_swapper = '<html>'.
+        '<head>'.
+        '<script src="//j.wovn.io/1" '.
+        'data-wovnio="key=TOKEN&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases=[]&amp;langParamName=wovn" '.
+        'data-wovnio-info="version=WOVN.php_VERSION" '.
+        'async></script>'.
+        '<link rel="alternate" hreflang="fr" href="http://localhost/fr/index.html">'.
+        '</head>'.
+        '<body>test</body>'.
+        '</html>';
+
+        $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/index.html')->body);
+        $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/en/index.html')->body);
+    }
+}

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -82,6 +82,7 @@ class APITest extends \PHPUnit_Framework_TestCase
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_body,
+            'insert_hreflangs' => $store->settings['insert_hreflangs']
         );
 
         return array_merge($data, $extra);

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -82,7 +82,7 @@ class APITest extends \PHPUnit_Framework_TestCase
             'product' => WOVN_PHP_NAME,
             'version' => WOVN_PHP_VERSION,
             'body' => $converted_body,
-            'insert_hreflangs' => $store->settings['insert_hreflangs']
+            'insert_hreflangs' => json_encode($store->settings['insert_hreflangs'])
         );
 
         return array_merge($data, $extra);
@@ -134,8 +134,12 @@ class APITest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
         $this->assertEquals($this->getExpectedApiUrl($store, $headers, $original_html), $url);
-        $expected_head_content = $this->getExpectedHtmlHeadContent($store, $headers);
-        $expected_html_before_send = "<html><head>$expected_head_content</head><body><h1>en</h1></body></html>";
+        $expected_html_before_send = '<html><head>'.
+        '<meta name="robots" content="noindex">'.
+        '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async>'.
+        '</script></head>'.
+        '<body><h1>en</h1>'.
+        '</body></html>';
         $this->assertEquals($this->getExpectedData($store, $headers, $expected_html_before_send, array('no_index_langs' => json_encode(array('en')))), $data, "should contain extra setting");
     }
 

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -660,7 +660,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
         $converter = new HtmlConverter(null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeCustomIgnoreClass');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeCustomIgnoreClass');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -672,7 +672,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -684,7 +684,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -696,7 +696,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -708,7 +708,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -720,7 +720,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -732,7 +732,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -744,7 +744,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><script>console.log("hello")</script>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -756,7 +756,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -660,7 +660,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
         $converter = new HtmlConverter(null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeCustomIgnoreClass');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeCustomIgnoreClass');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -672,7 +672,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeWovnIgnore');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -684,7 +684,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -696,7 +696,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -708,7 +708,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -720,7 +720,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -732,7 +732,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeForm');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));
@@ -744,7 +744,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><body><script>console.log("hello")</script>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
         $keys = $marker->keys();
 
         $this->assertEquals(1, count($keys));
@@ -756,7 +756,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', 'removeScript');
+        list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
         $keys = $marker->keys();
 
         $this->assertEquals(2, count($keys));

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -108,6 +108,69 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected_html, $translated_html);
     }
 
+    public function testinsertSnippetAndHreflangTagsWithInsertHreflangsFalse()
+    {
+        $html = '<html>' .
+            '<head>' .
+            '</head>' .
+            '<body>' .
+            '<a>hello</a>' .
+            '</body>' .
+            '</html>';
+        $settings = array(
+            'supported_langs' => array('en', 'vi'),
+            'lang_param_name' => 'wovn',
+            'insert_hreflangs' => false
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+        $expected_html = '<html><body><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script><a>hello</a></body></html>';
+        $expected_html = '<html>' .
+            '<head>' .
+            '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+            '</head>' .
+            '<body>' .
+            '<a>hello</a>' .
+            '</body>' .
+            '</html>';
+        $this->assertEquals($expected_html, $translated_html);
+    }
+
+    public function testinsertSnippetAndHreflangTagsWithInsertHreflangsFalseAndExistingHreflang()
+    {
+        $html = '<html>' .
+            '<head>' .
+            '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+            '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr">' .
+            '</head>' .
+            '<body>' .
+            '<a>hello</a>' .
+            '</body>' .
+            '</html>';
+        $settings = array(
+            'supported_langs' => array('en', 'vi'),
+            'lang_param_name' => 'wovn',
+            'insert_hreflangs' => false
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+
+        $expected_html = '<html>' .
+            '<head>' .
+            '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+            '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+            '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr">' .
+            '</head>' .
+            '<body>' .
+            '<a>hello</a>' .
+            '</body>' .
+            '</html>';
+        $this->assertEquals($expected_html, $translated_html);
+    }
+
     public function testInsertSnippetAndHreflangTagsWithCustomAlias()
     {
         $html = '<html><body><a>hello</a></body></html>';

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -9,166 +9,163 @@ use \Wovnio\ModifiedVendor\SimpleHtmlDom;
 
 class HtmlConverterTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConvertAndRevertAtStackOverflow()
+    public function testInsertSnippetAndHreflangTagsWithSampleWebsites()
     {
         libxml_use_internal_errors(true);
-        $html = file_get_contents('test/fixtures/real_html/stack_overflow.html');
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
 
-        $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_expected.html');
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
-        $expected_html = $doc->saveHTML();
-
-        $actual_html_text = $marker->revert($translated_html);
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
-        $actual_html = $doc->saveHTML();
-
-        $this->assertEquals($expected_html, $actual_html);
-    }
-
-    public function testConvertAndRevertAtYoutube()
-    {
-        libxml_use_internal_errors(true);
-        $html = file_get_contents('test/fixtures/real_html/youtube.html');
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
-
-        $expected_html_text = file_get_contents('test/fixtures/real_html/youtube_expected.html');
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
-        $expected_html = $doc->saveHTML();
-
-        $actual_html_text = $marker->revert($translated_html);
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
-        $actual_html = $doc->saveHTML();
-
-        $this->assertEquals($expected_html, $actual_html);
-    }
-
-    public function testConvertAndRevertAtYelp()
-    {
-        libxml_use_internal_errors(true);
-        $html = file_get_contents('test/fixtures/real_html/yelp.html');
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
-
-        $expected_html_text = file_get_contents('test/fixtures/real_html/yelp_expected.html');
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
-        $expected_html = $doc->saveHTML();
-
-        $actual_html_text = $marker->revert($translated_html);
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
-        $actual_html = $doc->saveHTML();
-
-        $this->assertEquals($expected_html, $actual_html);
-    }
-
-    public function testConvertAndRevertAtYahooJp()
-    {
-        libxml_use_internal_errors(true);
-        $html = file_get_contents('test/fixtures/real_html/yahoo_jp.html');
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $converter->insertSnippetAndHreflangTags(false);
-
-        $expected_html_text = file_get_contents('test/fixtures/real_html/yahoo_jp_expected.html');
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($expected_html_text, 'HTML-ENTITIES', "utf-8"));
-        $expected_html = $doc->saveHTML();
-
-        $actual_html_text = $marker->revert($translated_html);
-        $doc = new \DOMDocument("1.0", "ISO-8859-15");
-        $doc->loadHTML(mb_convert_encoding($actual_html_text, 'HTML-ENTITIES', "utf-8"));
-        $actual_html = $doc->saveHTML();
-
-        $this->assertEquals($expected_html, $actual_html);
-    }
-
-    public function testinsertSnippetAndHreflangTags()
-    {
-        $html = '<html><body><a>hello</a></body></html>';
-        $settings = array(
-            'supported_langs' => array('en', 'vi'),
-            'lang_param_name' => 'wovn'
+        $websites = array(
+            'real_html/stack_overflow',
+            'real_html/youtube',
+            'real_html/yelp',
+            'real_html/yahoo_jp'
         );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
 
-        $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" async></script><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
+        foreach ($websites as $website_name) {
+            // insert snippet and hreflang
+            $original_html = file_get_contents("test/fixtures/{$website_name}.html");
+            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
+            $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+            $translated_html = $converter->insertSnippetAndHreflangTags($original_html, false);
+
+            $actual_html = $this->convertEncordingAndCorrectHtml($converter->revertMarkers($translated_html));
+            $expected_html = $this->convertEncordingAndCorrectHtml(file_get_contents("test/fixtures/{$website_name}_expected.html"));
+
+            $this->assertEquals($expected_html, $actual_html);
+        }
     }
 
-    public function testinsertSnippetAndHreflangTagsWithInsertHreflangsFalse()
+    public function testInsertSnippetAndHreflangTags()
     {
-        $html = '<html>' .
-            '<head>' .
-            '</head>' .
-            '<body>' .
-            '<a>hello</a>' .
-            '</body>' .
-            '</html>';
-        $settings = array(
-            'supported_langs' => array('en', 'vi'),
-            'lang_param_name' => 'wovn',
-            'insert_hreflangs' => false
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $html_cases = array(
+            array(
+                'Common case',
 
-        $expected_html = '<html><body><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script><a>hello</a></body></html>';
-        $expected_html = '<html>' .
-            '<head>' .
-            '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
-            '</head>' .
-            '<body>' .
-            '<a>hello</a>' .
-            '</body>' .
-            '</html>';
-        $this->assertEquals($expected_html, $translated_html);
+                '<html><head></head><body><a>hello</a></body></html>',
+
+                '<html>' .
+                '<head>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+                '<link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi">' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '</head>' .
+                '<body>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>'
+            ),
+            array(
+                'without head tag',
+
+                '<html><body><a>hello</a></body></html>',
+
+                '<html>' .
+                '<body>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+                '<link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi">' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>'
+            ),
+            array(
+                'without body tag',
+
+                '<html><a>hello</a></html>',
+
+                '<html>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+                '<link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi">' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '<a>hello</a>' .
+                '</html>'
+            ),
+            array(
+                'with existing hreflang',
+
+                '<html>' .
+                '<body>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/?wovn=en" existing-hreflang-supported>' .
+                '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr" existing-hreflang-not-supported>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>',
+
+                '<html>' .
+                '<body>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
+                '<link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi">' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr" existing-hreflang-not-supported>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>'
+            )
+        );
+        foreach ($html_cases as $case) {
+            list($message, $original_html, $expected_html) = $case;
+            $settings = array(
+                'supported_langs' => array('en', 'vi'),
+                'lang_param_name' => 'wovn'
+            );
+            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+            $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+            $translated_html = $converter->insertSnippetAndHreflangTags($original_html, false);
+
+            $this->assertEquals($expected_html, $translated_html, $message);
+        }
     }
 
-    public function testinsertSnippetAndHreflangTagsWithInsertHreflangsFalseAndExistingHreflang()
+    public function testInsertSnippetAndHreflangTagsWithInsertHreflangsFalse()
     {
-        $html = '<html>' .
-            '<head>' .
-            '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
-            '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr">' .
-            '</head>' .
-            '<body>' .
-            '<a>hello</a>' .
-            '</body>' .
-            '</html>';
-        $settings = array(
-            'supported_langs' => array('en', 'vi'),
-            'lang_param_name' => 'wovn',
-            'insert_hreflangs' => false
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $html_cases = array(
+            array(
+                'common case',
 
-        $expected_html = '<html>' .
-            '<head>' .
-            '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
-            '<link rel="alternate" hreflang="en" href="http://my-site.com/">' .
-            '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr">' .
-            '</head>' .
-            '<body>' .
-            '<a>hello</a>' .
-            '</body>' .
-            '</html>';
-        $this->assertEquals($expected_html, $translated_html);
+                '<html><head></head><body><a>hello</a></body></html>',
+
+                '<html>' .
+                '<head>' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '</head>' .
+                '<body>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>'
+            ),
+            array(
+                'with existing hreflang',
+
+                '<html>' .
+                '<body>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/?wovn=en" existing-hreflang-supported>' .
+                '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr" existing-hreflang-not-supported>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>',
+
+                '<html>' .
+                '<body>' .
+                '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>' .
+                '<link rel="alternate" hreflang="en" href="http://my-site.com/?wovn=en" existing-hreflang-supported>' .
+                '<link rel="alternate" hreflang="fr" href="http://my-site.com/?wovn=fr" existing-hreflang-not-supported>' .
+                '<a>hello</a>' .
+                '</body>' .
+                '</html>'
+            )
+        );
+        foreach ($html_cases as $case) {
+            list($message, $original_html, $expected_html) = $case;
+            $settings = array(
+                'supported_langs' => array('en', 'vi'),
+                'lang_param_name' => 'wovn',
+                'insert_hreflangs' => false
+            );
+            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+            $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+            $translated_html = $converter->insertSnippetAndHreflangTags($original_html, false);
+
+            $this->assertEquals($expected_html, $translated_html, $message);
+        }
     }
 
     public function testInsertSnippetAndHreflangTagsWithCustomAlias()
@@ -182,8 +179,8 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'path'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"fr\" href=\"http://my-site.com/fr/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;custom_en&quot;}&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" async></script><a>hello</a></body></html>";
         $this->assertEquals($expected_html, $translated_html);
@@ -199,8 +196,8 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'custom_domain'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, array('HTTP_HOST' => 'testsite.com'));
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html = '<html>'.
         '<body>'.
@@ -208,6 +205,32 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         '<script src="//j.wovn.io/1"'.
         ' data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=custom_domain&amp;langCodeAliases=[]&amp;langParamName=wovn&amp;customDomainLangs={&quot;testsite.com&quot;:&quot;en&quot;,&quot;testsite.com\/fr&quot;:&quot;fr&quot;}"'.
         ' data-wovnio-info="version=WOVN.php_VERSION"'.
+        ' async></script>'.
+        '<a>hello</a>'.
+        '</body>'.
+        '</html>';
+        $this->assertEquals($expected_html, $translated_html);
+    }
+
+    public function testInsertSnippetAndHreflangTagsWithFallback()
+    {
+        $html = '<html><body><a>hello</a></body></html>';
+        $settings = array(
+            'supported_langs' => array('en', 'vi'),
+            'lang_param_name' => 'wovn'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, true);
+
+        $expected_html = '<html>'.
+        '<body>'.
+        '<link rel="alternate" hreflang="en" href="http://my-site.com/">'.
+        '<link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi">'.
+        '<script src="//j.wovn.io/1"'.
+        ' data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn"'.
+        ' data-wovnio-info="version=WOVN.php_VERSION"'.
+        ' data-wovnio-type="fallback_snippet"'.
         ' async></script>'.
         '<a>hello</a>'.
         '</body>'.
@@ -225,7 +248,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'path'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/ja/';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -247,7 +270,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/custom_en/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('en'));
         $this->assertEquals($expected_href, $generated_href);
@@ -269,7 +292,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/custom_en/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('en'));
         $this->assertEquals($expected_href, $generated_href);
@@ -291,7 +314,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/custom_en/news/blog/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('en'));
         $this->assertEquals($expected_href, $generated_href);
@@ -312,7 +335,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/ja/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -334,7 +357,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/custom_en/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('en'));
         $this->assertEquals($expected_href, $generated_href);
@@ -356,7 +379,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         );
 
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/ja/blog/news/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -372,7 +395,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'query'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/?wovn=ja';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -389,7 +412,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'query'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/?wovn=ja';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -405,7 +428,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'lang_param_name' => 'lan'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://my-site.com/?lan=ja';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -421,7 +444,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'url_pattern_name' => 'subdomain'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://ja.my-site.com/';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
@@ -447,40 +470,123 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/pages.html', $headers->pathname);
         $this->assertEquals('en', $headers->requestLang());
         $this->assertEquals('custom_en.my-site.com', $headers->host);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         $expected_href = 'http://ja.my-site.com/pages.html';
         $generated_href = TestUtils::invokeMethod($converter, 'buildHrefLang', array('ja'));
         $this->assertEquals($expected_href, $generated_href);
     }
 
-    public function testinsertSnippetAndHreflangTagsWithErrorMark()
-    {
-        $html = '<html><body><a>hello</a></body></html>';
-        $settings = array(
-            'supported_langs' => array('en', 'vi'),
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(true);
-
-        $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
     public function testConvertToAppropriateBodyForApi()
     {
-        $html = '<html><body><a>hello</a></body></html>';
-        $settings = array(
-            'supported_langs' => array('en', 'vi'),
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
+        $html_cases = array(
+            array(
+                'common case',
 
-        $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
+                '<html><head></head><body><a>hello</a></body></html>',
+
+                '<html><head></head><body><a>hello</a></body></html>',
+
+                '<html><head></head><body><a>hello</a></body></html>'
+            ),
+            array(
+                'with wovn-ignore to html',
+
+                '<html wovn-ignore><body><a>hello</a></body></html>',
+
+                '<html wovn-ignore><!-- __wovn-backend-ignored-key-0 --></html>',
+
+                '<html wovn-ignore><body><a>hello</a></body></html>'
+            ),
+            array(
+                'with wovn-ignore to elements',
+
+                '<html><body>'.
+                '<a wovn-ignore>hello 1</a>'.
+                '<div wovn-ignore><span>hello 2</span></div>'.
+                '<a data-wovn-ignore>hello 3</a>'.
+                '<div data-wovn-ignore><span>hello 4</span></div>'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<a wovn-ignore><!-- __wovn-backend-ignored-key-0 --></a>'.
+                '<div wovn-ignore><!-- __wovn-backend-ignored-key-1 --></div>'.
+                '<a data-wovn-ignore><!-- __wovn-backend-ignored-key-2 --></a>'.
+                '<div data-wovn-ignore><!-- __wovn-backend-ignored-key-3 --></div>'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<a wovn-ignore>hello 1</a>'.
+                '<div wovn-ignore><span>hello 2</span></div>'.
+                '<a data-wovn-ignore>hello 3</a>'.
+                '<div data-wovn-ignore><span>hello 4</span></div>'.
+                '</body></html>',
+            ),
+            array(
+                'with ignore_class',
+
+                '<html><body>'.
+                '<span class="ignore-class">hello 1</span>'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<span class="ignore-class"><!-- __wovn-backend-ignored-key-0 --></span>'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<span class="ignore-class">hello 1</span>'.
+                '</body></html>',
+            ),
+            array(
+                'with form',
+
+                '<html><body>'.
+                '<form><input type="text" name="name" >hello 1</form>'.
+                '<input type="hidden" value="hello 2">'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<form><!-- __wovn-backend-ignored-key-0 --></form>'.
+                '<input type="hidden" value="__wovn-backend-ignored-key-1">'.
+                '</body></html>',
+
+                '<html><body>'.
+                '<form><input type="text" name="name" >hello 1</form>'.
+                '<input type="hidden" value="hello 2">'.
+                '</body></html>',
+            ),
+            array(
+                'with script',
+
+                '<html><head>'.
+                '<script type="text/javascript">document.write("this is test.");</script>'.
+                '<script type="application/ld+json">{test: "test"}</script>'.
+                '</head><body></body></html>',
+
+                '<html><head>'.
+                '<script type="text/javascript"><!-- __wovn-backend-ignored-key-0 --></script>'.
+                '<script type="application/ld+json">{test: "test"}</script>'.
+                '</head><body></body></html>',
+
+                '<html><head>'.
+                '<script type="text/javascript">document.write("this is test.");</script>'.
+                '<script type="application/ld+json">{test: "test"}</script>'.
+                '</head><body></body></html>',
+            ),
+        );
+        foreach ($html_cases as $case) {
+            list($message, $original_html, $expected_converted_html, $expected_reverted_html) = $case;
+            $settings = array(
+                'supported_langs' => array('en', 'vi'),
+                'lang_param_name' => 'wovn',
+                'ignore_class' => array('ignore-class')
+            );
+            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+            $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+            $converted_html = $converter->convertToAppropriateBodyForApi($original_html, false);
+
+            $this->assertEquals($expected_converted_html, $converted_html, $message);
+            $this->assertEquals($expected_reverted_html, $converter->revertMarkers($converted_html), $message);
+        }
     }
 
     public function testConvertToAppropriateBodyForApiDoesNotFailForEmptyContent()
@@ -495,11 +601,11 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $converted_html = $converter->convertToAppropriateBodyForApi($html);
 
-        $expected_html = '<html><body><link rel="alternate" hreflang="en" href="http://my-site.com/"><link rel="alternate" hreflang="vi" href="http://my-site.com/?wovn=vi"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async></script><p>' . $long_string . '</p></body></html>';
-        $this->assertEquals($expected_html, $translated_html);
+        $expected_html = '<html><body><p>' . $long_string . '</p></body></html>';
+        $this->assertEquals($expected_html, $converted_html);
     }
 
     public function testConvertToAppropriateBodyForApiDoesNotFailForContentOverDefaultSimpleHtmlDomMaxSize()
@@ -510,136 +616,11 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $converted_html = $converter->convertToAppropriateBodyForApi($html);
 
         $expected_html = "";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsWithEmptySupportedLangs()
-    {
-        $html = '<html><body><a>hello</a></body></html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsWithHead()
-    {
-        $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsWithoutBody()
-    {
-        $html = '<html>hello<a>world</a></html>';
-        $settings = array(
-            'supported_langs' => array(),
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>hello<a>world</a></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsOnDefaultLangWithQuerySupportedLangs()
-    {
-        $html = '<html>hello<a>world</a></html>';
-        $settings = array(
-            'default_lang' => 'en',
-            'supported_langs' => array('en', 'ja', 'vi'),
-            'url_pattern_name' => 'query',
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/?wovn=ja\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/?wovn=vi\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>hello<a>world</a></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsOnDefaultLangWithPathSupportedLangs()
-    {
-        $html = '<html>hello<a>world</a></html>';
-        $settings = array(
-            'default_lang' => 'en',
-            'supported_langs' => array('en', 'ja', 'vi'),
-            'url_pattern_name' => 'path',
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://my-site.com/ja/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://my-site.com/vi/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>hello<a>world</a></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertSnippetAndHreflangTagsOnDefaultLangWithSubdomainSupportedLangs()
-    {
-        $html = '<html>hello<a>world</a></html>';
-        $settings = array(
-            'default_lang' => 'en',
-            'supported_langs' => array('en', 'ja', 'vi'),
-            'url_pattern_name' => 'subdomain',
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><link rel=\"alternate\" hreflang=\"ja\" href=\"http://ja.my-site.com/\"><link rel=\"alternate\" hreflang=\"vi\" href=\"http://vi.my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=subdomain&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>hello<a>world</a></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testConvertToAppropriateBodyForApiWithEmptySupportedLangs()
-    {
-        $html = '<html><body><a>hello</a></body></html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><body><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testConvertToAppropriateBodyForApiWithHead()
-    {
-        $html = '<html><head><title>TITLE</title></head><body><a>hello</a></body></html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><head><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script><title>TITLE</title></head><body><a>hello</a></body></html>";
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testConvertToAppropriateBodyForApiWithoutBody()
-    {
-        $html = '<html>hello<a>world</a></html>';
-        $settings = array(
-            'supported_langs' => array(),
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
-
-        $expected_html = "<html><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>hello<a>world</a></html>";
-        $this->assertEquals($expected_html, $translated_html);
+        $this->assertEquals($expected_html, $converted_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithoutEncoding()
@@ -647,13 +628,13 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         $html = mb_convert_encoding('<html>こんにちは</html>', 'SJIS');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->convertToAppropriateBodyForApi();
+        $converter = new HtmlConverter(null, $store->settings['project_token'], $store, $headers);
+        $converted_html = $converter->convertToAppropriateBodyForApi($html);
 
-        $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>こんにちは</html>";
+        $expected_html = "<html>こんにちは</html>";
         $expected_html = mb_convert_encoding($expected_html, 'SJIS');
 
-        $this->assertEquals($expected_html, $translated_html);
+        $this->assertEquals($expected_html, $converted_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithSupportedEncoding()
@@ -661,86 +642,13 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
         foreach (HtmlConverter::$supportedEncodings as $encoding) {
             $html = mb_convert_encoding('<html>こんにちは</html>', $encoding);
             list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-            $converter = new HtmlConverter($html, $encoding, $store->settings['project_token'], $store, $headers);
-            list($translated_html) = $converter->convertToAppropriateBodyForApi();
+            $converter = new HtmlConverter($encoding, $store->settings['project_token'], $store, $headers);
+            $converted_html = $converter->convertToAppropriateBodyForApi($html);
 
-            $expected_html = "<html><link rel=\"alternate\" hreflang=\"en\" href=\"http://my-site.com/\"><script src=\"//j.wovn.io/1\" data-wovnio=\"key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn\" data-wovnio-info=\"version=WOVN.php_VERSION\" data-wovnio-type=\"fallback_snippet\" async></script>こんにちは</html>";
+            $expected_html = "<html>こんにちは</html>";
             $expected_html = mb_convert_encoding($expected_html, $encoding);
-            $this->assertEquals($expected_html, $translated_html);
+            $this->assertEquals($expected_html, $converted_html);
         }
-    }
-
-    public function testConvertToAppropriateBodyForApiWithWovnSnippet()
-    {
-        $original_html = '<html>'.
-            '<head>'.
-            '<script src="//j.wovn.io/1" data-wovnio="key=123456" async></script>'.
-            '</head>'.
-            '<body>'.
-            '<a>hello</a>'.
-            '</body>'.
-            '</html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeSnippet');
-
-        $this->assertEquals(0, count($marker->keys()));
-        $expected_html = '<html>'.
-            '<head>'.
-            '</head>'.
-            '<body>'.
-            '<a>hello</a>'.
-            '</body>'.
-            '</html>';
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testConvertToAppropriateBodyForApiWithWovnIgnore()
-    {
-        $original_html = '<html>'.
-            '<body>'.
-            '<a wovn-ignore>hello</a>'.
-            '<a wovn-ignore="">wovn</a>'.
-            '<a wovn-ignore="true">world</a>'.
-            '</body>'.
-            '</html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeWovnIgnore');
-
-        $this->assertEquals(3, count($marker->keys()));
-        $expected_html = '<html>'.
-            '<body>'.
-            '<a wovn-ignore><!-- __wovn-backend-ignored-key-0 --></a>'.
-            '<a wovn-ignore=""><!-- __wovn-backend-ignored-key-1 --></a>'.
-            '<a wovn-ignore="true"><!-- __wovn-backend-ignored-key-2 --></a>'.
-            '</body>'.
-            '</html>';
-        $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testConvertToAppropriateBodyForApiWithDataWovnIgnore()
-    {
-        $original_html = '<html>'.
-            '<body>'.
-            '<a data-wovn-ignore>hello</a>'.
-            '<a data-wovn-ignore="">wovn</a>'.
-            '<a data-wovn-ignore="true">world</a>'.
-            '</body>'.
-            '</html>';
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($original_html, null, $store->settings['project_token'], $store, $headers);
-        list($translated_html, $marker) = $this->executeConvert($converter, $original_html, 'UTF-8', '_removeWovnIgnore');
-
-        $this->assertEquals(3, count($marker->keys()));
-        $expected_html = '<html>'.
-            '<body>'.
-            '<a data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></a>'.
-            '<a data-wovn-ignore=""><!-- __wovn-backend-ignored-key-1 --></a>'.
-            '<a data-wovn-ignore="true"><!-- __wovn-backend-ignored-key-2 --></a>'.
-            '</body>'.
-            '</html>';
-        $this->assertEquals($expected_html, $translated_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithCustomIgnoreClass()
@@ -751,7 +659,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, null, $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter(null, $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeCustomIgnoreClass');
         $keys = $marker->keys();
 
@@ -763,7 +671,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
         $keys = $marker->keys();
 
@@ -775,7 +683,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><form>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
@@ -787,7 +695,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><form>hello<input type="button" value="click"></form>world<form>hello2<input type="button" value="click2"></form></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
@@ -799,7 +707,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><form wovn-ignore>hello<input type="button" value="click"></form>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
@@ -811,7 +719,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><input type="hidden" value="aaaaa">world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
@@ -823,7 +731,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><input type="hidden" value="aaaaa">world<input type="hidden" value="aaaaa"></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeForm');
         $keys = $marker->keys();
 
@@ -835,7 +743,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body><script>console.log("hello")</script>world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
         $keys = $marker->keys();
 
@@ -847,7 +755,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><head><script>console.log("hello")</script></head><body>world<script>console.log("hello2")</script></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeScript');
         $keys = $marker->keys();
 
@@ -859,7 +767,7 @@ class HtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body>hello<!-- backend-wovn-ignore    -->ignored <!--/backend-wovn-ignore-->  world</body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
         $keys = $marker->keys();
 
@@ -879,7 +787,7 @@ ignored2
 bye
 </body></html>";
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeRemoveBackendWovnIgnoreComment($converter, $html);
         $keys = $marker->keys();
 
@@ -891,26 +799,6 @@ bye
 bye
 </body></html>";
         $this->assertEquals($expected_html, $translated_html);
-    }
-
-    public function testInsertHreflang()
-    {
-        libxml_use_internal_errors(true);
-        $html = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang.html');
-        $settings = array(
-            'default_lang' => 'ja',
-            'supported_langs' => array('en', 'vi'),
-            'disable_api_request_for_default_lang' => true,
-            'url_pattern_name' => 'path',
-            'lang_param_name' => 'wovn'
-        );
-        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
-
-        $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang_expected.html');
-
-        $this->assertEquals($expected_html_text, $translated_html);
     }
 
     public function testInsertHreflangWithCustomLangCodes()
@@ -926,8 +814,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_with_custom_lang_codes_expected.html');
 
@@ -947,8 +835,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_with_default_lang_alias_expected.html');
 
@@ -968,8 +856,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_with_default_lang_alias_expected_subdomain.html');
 
@@ -988,8 +876,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_head_style_expected.html');
 
@@ -1008,8 +896,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_body_expected.html');
 
@@ -1028,8 +916,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_snippet_when_already_exist_expected.html');
 
@@ -1048,8 +936,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_html_expected.html');
 
@@ -1068,8 +956,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_with_exist_hreflang_expected.html');
         $this->assertEquals($expected_html_text, $translated_html);
@@ -1087,8 +975,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/real_html/stack_overflow_hreflang_html_entities_expected.html');
 
@@ -1107,8 +995,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected.html');
 
@@ -1127,8 +1015,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_lang_alias.html');
 
@@ -1146,8 +1034,8 @@ bye
             'lang_param_name' => 'language'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_lang_param_name.html');
 
@@ -1166,8 +1054,8 @@ bye
             'lang_param_name' => 'wovn'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias.html');
 
@@ -1187,8 +1075,8 @@ bye
         );
         $env = array('REQUEST_URI' => '/dir1/dir2/');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_default_lang_alias_trailing_slash.html');
 
@@ -1208,8 +1096,8 @@ bye
             'no_index_langs' => array('en')
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_noindex_langs.html');
 
@@ -1229,8 +1117,8 @@ bye
             'no_index_langs' => array('en', 'cs', 'fr')
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_multi_noindex_langs.html');
         $this->assertEquals($expected_html_text, $translated_html);
@@ -1249,8 +1137,8 @@ bye
         );
         $env = array('REQUEST_URI' => '/dir1/dir2/');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_site_prefix_path.html');
         $this->assertEquals($expected_html_text, $translated_html);
@@ -1270,8 +1158,8 @@ bye
         );
         $env = array('REQUEST_URI' => '/dir1/dir2/');
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
-        $converter = new HtmlConverter($html, 'UTF-8', $store->settings['project_token'], $store, $headers);
-        list($translated_html) = $converter->insertSnippetAndHreflangTags(false);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndHreflangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_site_prefix_path_and_custom_lang_codes.html');
         $this->assertEquals($expected_html_text, $translated_html);
@@ -1305,5 +1193,12 @@ bye
         $converted_html = $method->invoke($converter, $html, $marker);
 
         return array($converted_html, $marker);
+    }
+
+    private function convertEncordingAndCorrectHtml($html_text, $encoding = 'utf-8')
+    {
+        $doc = new \DOMDocument("1.0", "ISO-8859-15");
+        $doc->loadHTML(mb_convert_encoding($html_text, 'HTML-ENTITIES', $encoding));
+        return $doc->saveHTML();
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-572

Don't touch hreflang, if `insert_hreflangs` is false.

WOVN.php has two logic to insert hreflang.
I removed it from `convertToAppropriateBodyForApi` and changed to only use `insertSnippetAndHreflangTags`.

### Comments
html-swapper part:
https://github.com/WOVNio/html-swapper/pull/541

### Release comments (new feature)
