### PR TITLE
Add debug request parameters

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.6.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.7.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -32,7 +32,7 @@ if (!$store->isValid()) {
     return false;
 }
 
-$queryString = parse_url($_SERVER['REQUEST_URI'])['query'];
+$queryString = $_SERVER['REQUEST_URI'];
 $debugModeEnable = $store->settings['debug_mode'];
 $requestOptions = new RequestOptions($queryString, $debugModeEnable);
 

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -59,7 +59,7 @@ if (!Utils::isIgnoredPath($uri, $store)) {
         $diagnostics = new Diagnostics($store);
     }
     // use the callback of ob_start to modify the content and return
-    ob_start(function ($buffer) use ($headers, $store, $diagnostics, $benchmarkStart) {
+    ob_start(function ($buffer) use ($headers, $store, $diagnostics, $benchmarkStart, $requestOptions) {
         if ($headers->shouldRedirect()) {
             // this carries an implied HTTP 302
             header("Location: " . $headers->computeRedirectUrl());
@@ -76,7 +76,7 @@ if (!Utils::isIgnoredPath($uri, $store)) {
             return $buffer;
         }
 
-        $translatedBuffer = API::translate($store, $headers, $buffer);
+        $translatedBuffer = API::translate($store, $headers, $buffer, $requestOptions->getCacheDisableMode());
 
         if (Utils::wovnDiagnosticsEnabled($store, $headers)) {
             $benchmarkEnd = microtime(true) * 1000;

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -32,9 +32,9 @@ if (!$store->isValid()) {
     return false;
 }
 
-$queryString = $_SERVER['REQUEST_URI'];
+parse_str($headers->query, $queryStringArray);
 $debugModeEnable = $store->settings['debug_mode'];
-$requestOptions = new RequestOptions($queryString, $debugModeEnable);
+$requestOptions = new RequestOptions($queryStringArray, $debugModeEnable);
 
 if ($requestOptions->getDisableMode()) {
     return true;

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -76,7 +76,7 @@ if (!Utils::isIgnoredPath($uri, $store)) {
             return $buffer;
         }
 
-        $translatedBuffer = API::translate($store, $headers, $buffer, $requestOptions->getCacheDisableMode());
+        $translatedBuffer = API::translate($store, $headers, $buffer, $requestOptions);
 
         if (Utils::wovnDiagnosticsEnabled($store, $headers)) {
             $benchmarkEnd = microtime(true) * 1000;

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -8,6 +8,7 @@ require_once 'wovnio/wovnphp/Utils.php';
 require_once 'wovnio/wovnphp/API.php';
 require_once 'wovnio/wovnphp/Url.php';
 require_once 'wovnio/wovnphp/Diagnostics.php';
+require_once 'wovnio/wovnphp/RequestOptions.php';
 require_once 'wovnio/html/HtmlConverter.php';
 require_once 'wovnio/html/HtmlReplaceMarker.php';
 require_once 'wovnio/modified_vendor/SimpleHtmlDom.php';
@@ -20,10 +21,15 @@ use Wovnio\Wovnphp\Logger;
 use Wovnio\Wovnphp\Utils;
 use Wovnio\Wovnphp\API;
 use Wovnio\Wovnphp\Diagnostics;
+use Wovnio\Wovnphp\RequestOptions;
 use \Wovnio\Wovnphp\CookieLang;
 
 // GET STORE AND HEADERS
 list($store, $headers) = Utils::getStoreAndHeaders($_SERVER, $_COOKIE);
+// RequestOptions here?
+
+$queryString = parse_url($headers->getEnv()['REQUEST_URI'])['query'];
+$requestOptions = new RequestOptions($queryString);
 
 if (!$store->isValid()) {
     Logger::get()->critical('WOVN Invalid configuration');

--- a/src/wovn_interceptor.php
+++ b/src/wovn_interceptor.php
@@ -26,14 +26,18 @@ use \Wovnio\Wovnphp\CookieLang;
 
 // GET STORE AND HEADERS
 list($store, $headers) = Utils::getStoreAndHeaders($_SERVER, $_COOKIE);
-// RequestOptions here?
-
-$queryString = parse_url($headers->getEnv()['REQUEST_URI'])['query'];
-$requestOptions = new RequestOptions($queryString);
 
 if (!$store->isValid()) {
     Logger::get()->critical('WOVN Invalid configuration');
     return false;
+}
+
+$queryString = parse_url($_SERVER['REQUEST_URI'])['query'];
+$debugModeEnable = $store->settings['debug_mode'];
+$requestOptions = new RequestOptions($queryString, $debugModeEnable);
+
+if ($requestOptions->getDisableMode()) {
+    return true;
 }
 
 // Make it available for user application

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -10,7 +10,7 @@ use \Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
 class API
 {
-    public static function url($store, $headers, $original_content)
+    public static function url($store, $headers, $original_content, $cache_disable_mode)
     {
         $token = $store->settings['project_token'];
         $path = $headers->pathnameKeepTrailingSlash;
@@ -19,12 +19,15 @@ class API
         ksort($store->settings);
         $settings_hash = md5(serialize($store->settings));
         $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
+        if ($cache_disable_mode) {
+            $cache_key . "&timestamp=" . time();
+        }
         return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key; //append on to cache key with current time or something to invalidate it
     }
 
-    public static function translate($store, $headers, $original_content)
+    public static function translate($store, $headers, $original_content, $cache_disable_mode)
     {
-        $api_url = self::url($store, $headers, $original_content);
+        $api_url = self::url($store, $headers, $original_content, $cache_disable_mode);
         $encoding = $store->settings['encoding'];
         $token = $store->settings['project_token'];
 

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -10,7 +10,7 @@ use \Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
 class API
 {
-    public static function url($store, $headers, $original_content, $requestOptions)
+    public static function url($store, $headers, $original_content, $request_options)
     {
         $token = $store->settings['project_token'];
         $path = $headers->pathnameKeepTrailingSlash;
@@ -19,15 +19,15 @@ class API
         ksort($store->settings);
         $settings_hash = md5(serialize($store->settings));
         $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
-        if ($requestOptions->getCacheDisableMode() || $requestOptions->getDebugMode()) {
+        if ($request_options->getCacheDisableMode() || $request_options->getDebugMode()) {
             $cache_key . "&timestamp=" . time();
         }
         return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;
     }
 
-    public static function translate($store, $headers, $original_content, $requestOptions)
+    public static function translate($store, $headers, $original_content, $request_options)
     {
-        $api_url = self::url($store, $headers, $original_content, $requestOptions);
+        $api_url = self::url($store, $headers, $original_content, $request_options);
         $encoding = $store->settings['encoding'];
         $token = $store->settings['project_token'];
 
@@ -69,7 +69,7 @@ class API
         if ($store->getCustomDomainLangs()) {
             $data['custom_domain_langs'] = json_encode($store->getCustomDomainLangs()->toHtmlSwapperHash());
         }
-        if ($requestOptions->getDebugMode()) {
+        if ($request_options->getDebugMode()) {
             $data['debug_mode'] = 'true';
         }
 

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -18,10 +18,12 @@ class API
         $body_hash = md5($original_content);
         ksort($store->settings);
         $settings_hash = md5(serialize($store->settings));
-        $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
+        $cache_key_string = "(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)";
         if ($request_options->getCacheDisableMode() || $request_options->getDebugMode()) {
-            $cache_key . "&timestamp=" . time();
+            $cache_key_string = $cache_key_string . "&timestamp=" . time();
         }
+        $cache_key = rawurlencode($cache_key_string);
+
         return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;
     }
 

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -19,7 +19,7 @@ class API
         ksort($store->settings);
         $settings_hash = md5(serialize($store->settings));
         $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
-        return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;
+        return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key; //append on to cache key with current time or something to invalidate it
     }
 
     public static function translate($store, $headers, $original_content)

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -10,7 +10,7 @@ use \Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
 class API
 {
-    public static function url($store, $headers, $original_content, $cache_disable_mode)
+    public static function url($store, $headers, $original_content, $requestOptions)
     {
         $token = $store->settings['project_token'];
         $path = $headers->pathnameKeepTrailingSlash;
@@ -19,15 +19,15 @@ class API
         ksort($store->settings);
         $settings_hash = md5(serialize($store->settings));
         $cache_key = rawurlencode("(token=$token&settings_hash=$settings_hash&body_hash=$body_hash&path=$path&lang=$lang)");
-        if ($cache_disable_mode) {
+        if ($requestOptions->getCacheDisableMode() || $requestOptions->getDebugMode()) {
             $cache_key . "&timestamp=" . time();
         }
         return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key; //append on to cache key with current time or something to invalidate it
     }
 
-    public static function translate($store, $headers, $original_content, $cache_disable_mode)
+    public static function translate($store, $headers, $original_content, $requestOptions)
     {
-        $api_url = self::url($store, $headers, $original_content, $cache_disable_mode);
+        $api_url = self::url($store, $headers, $original_content, $requestOptions);
         $encoding = $store->settings['encoding'];
         $token = $store->settings['project_token'];
 
@@ -68,6 +68,9 @@ class API
         }
         if ($store->getCustomDomainLangs()) {
             $data['custom_domain_langs'] = json_encode($store->getCustomDomainLangs()->toHtmlSwapperHash());
+        }
+        if ($requestOptions->getDebugMode()) {
+            $data['debug_mode'] = 'true';
         }
 
         try {

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -22,7 +22,7 @@ class API
         if ($requestOptions->getCacheDisableMode() || $requestOptions->getDebugMode()) {
             $cache_key . "&timestamp=" . time();
         }
-        return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key; //append on to cache key with current time or something to invalidate it
+        return $store->settings['api_url'] . 'translation?cache_key=' . $cache_key;
     }
 
     public static function translate($store, $headers, $original_content, $requestOptions)

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -13,11 +13,11 @@ class Headers
     public $host;
     public $pathname;
     public $url;
+    public $query;
 
     private $env;
     private $store;
     private $urlLang;
-    private $query;
     private $browserLang;
     private $cookieLang;
 

--- a/src/wovnio/wovnphp/RequestOptions.php
+++ b/src/wovnio/wovnphp/RequestOptions.php
@@ -25,17 +25,17 @@ class RequestOptions
     private $debugMode;
 
 
-    public function __construct($queryString, $debugModeEnable)
+    public function __construct($queryStringArray, $debugModeEnable)
     {
         $this->disableMode = false;
         $this->cacheDisableMode = false;
         $this->debugMode = false;
 
-        if ($queryString !== null) {
-            $this->disableMode = strpos($queryString, 'wovnDisable') !== false;
+        if ($queryStringArray !== null) {
+            $this->disableMode = array_key_exists('wovnDisable', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
             if ($debugModeEnable) {
-                $this->cacheDisableMode = strpos($queryString, 'wovnCacheDisable') !== false;
-                $this->debugMode = strpos($queryString, 'wovnDebugMode') !== false;
+                $this->cacheDisableMode = array_key_exists('wovnCacheDisable', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
+                $this->debugMode = array_key_exists('wovnDebugMode', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
             }
         }
     }

--- a/src/wovnio/wovnphp/RequestOptions.php
+++ b/src/wovnio/wovnphp/RequestOptions.php
@@ -34,8 +34,8 @@ class RequestOptions
         if ($queryStringArray !== null) {
             $this->disableMode = array_key_exists('wovnDisable', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
             if ($debugModeEnable) {
-                $this->cacheDisableMode = array_key_exists('wovnCacheDisable', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
-                $this->debugMode = array_key_exists('wovnDebugMode', $queryStringArray) && strcasecmp($queryStringArray['wovnDisable'], 'false') !== 0;
+                $this->cacheDisableMode = array_key_exists('wovnCacheDisable', $queryStringArray) && strcasecmp($queryStringArray['wovnCacheDisable'], 'false') !== 0;
+                $this->debugMode = array_key_exists('wovnDebugMode', $queryStringArray) && strcasecmp($queryStringArray['wovnDebugMode'], 'false') !== 0;
             }
         }
     }

--- a/src/wovnio/wovnphp/RequestOptions.php
+++ b/src/wovnio/wovnphp/RequestOptions.php
@@ -1,0 +1,72 @@
+<?php
+namespace Wovnio\Wovnphp;
+
+class RequestOptions
+{
+    /*
+     * disableMode:
+     *      - do nothing to the request
+     */
+    private $disable_mode;
+    /*
+     * cacheDisableMode:
+     *      - bypass cache for request to translation API
+     * Only available if debugMode is also turned on server side.
+     */
+    private $cache_disable_mode;
+    /*
+     * debugMode:
+     *      - activate extra debugging information.
+     *      - send "debug_mode=true" to translation API
+     *      - bypass cache for request to translation API
+     * Only available if debugMode is also turned on server side.
+     */
+    private $debug_mode;
+
+
+    public function __construct($queryString) {
+        error_log($queryString);
+
+        $this->disable_mode = false;
+        $this->cache_disable_mode = false;
+        $this->debug_mode = false;
+
+        if ($queryString !== null) {
+            $this->disable_mode = strpos($queryString, 'wovnDisable') !== false;
+            if ($store->settings['debug_mode']) {
+                $this->cache_disable_mode = strpos($queryString, 'wovnCacheDisable') !== false;
+                $this->debug_mode = strpos($queryString, 'wovnDebugMode') !== false;
+            }
+        }
+        
+        error_log($this->disable_mode);
+        error_log($this->cache_disable_mode);
+        error_log($this->debug_mode);
+
+
+        // TRANSLATE THIS TO PHP
+        // String query = ((HttpServletRequest)request).getQueryString();
+        // if (query != null) {
+        //     this.disableMode = query.matches("(.*)wovnDisable(.*)");
+        //     if (settings.debugMode) {
+        //         this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
+        //         this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
+        //     }
+        // }
+    }
+
+    public function getDisableMode()
+    {
+        return $this->disable_mode;
+    }
+
+    public function getCacheDisableMode()
+    {
+        return $this->cache_disable_mode;
+    }
+
+    public function getDebugMode()
+    {
+        return $this->debug_mode;
+    }
+}

--- a/src/wovnio/wovnphp/RequestOptions.php
+++ b/src/wovnio/wovnphp/RequestOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Wovnio\Wovnphp;
 
 class RequestOptions
@@ -7,54 +8,50 @@ class RequestOptions
      * disableMode:
      *      - do nothing to the request
      */
-    private $disable_mode;
+    private $disableMode;
     /*
      * cacheDisableMode:
      *      - bypass cache for request to translation API
      * Only available if debugMode is also turned on server side.
      */
-    private $cache_disable_mode;
+    private $cacheDisableMode;
     /*
      * debugMode:
      *      - activate extra debugging information.
-     *      - send "debug_mode=true" to translation API
+     *      - send "debugMode=true" to translation API
      *      - bypass cache for request to translation API
      * Only available if debugMode is also turned on server side.
      */
-    private $debug_mode;
+    private $debugMode;
 
 
-    public function __construct($queryString, $debugModeEnable) {
-        $this->disable_mode = false;
-        $this->cache_disable_mode = false;
-        $this->debug_mode = false;
+    public function __construct($queryString, $debugModeEnable)
+    {
+        $this->disableMode = false;
+        $this->cacheDisableMode = false;
+        $this->debugMode = false;
 
         if ($queryString !== null) {
-            $this->disable_mode = strpos($queryString, 'wovnDisable') !== false;
-            // error_log("Debug mode enable: " . $debugModeEnable);
+            $this->disableMode = strpos($queryString, 'wovnDisable') !== false;
             if ($debugModeEnable) {
-                $this->cache_disable_mode = strpos($queryString, 'wovnCacheDisable') !== false;
-                $this->debug_mode = strpos($queryString, 'wovnDebugMode') !== false;
+                $this->cacheDisableMode = strpos($queryString, 'wovnCacheDisable') !== false;
+                $this->debugMode = strpos($queryString, 'wovnDebugMode') !== false;
             }
         }
-        
-        // error_log("Disable mode:        " . $this->disable_mode);
-        // error_log("Cache disable mode:  " . $this->cache_disable_mode);
-        // error_log("Debug mode:          " . $this->debug_mode);
     }
 
     public function getDisableMode()
     {
-        return $this->disable_mode;
+        return $this->disableMode;
     }
 
     public function getCacheDisableMode()
     {
-        return $this->cache_disable_mode;
+        return $this->cacheDisableMode;
     }
 
     public function getDebugMode()
     {
-        return $this->debug_mode;
+        return $this->debugMode;
     }
 }

--- a/src/wovnio/wovnphp/RequestOptions.php
+++ b/src/wovnio/wovnphp/RequestOptions.php
@@ -24,35 +24,23 @@ class RequestOptions
     private $debug_mode;
 
 
-    public function __construct($queryString) {
-        error_log($queryString);
-
+    public function __construct($queryString, $debugModeEnable) {
         $this->disable_mode = false;
         $this->cache_disable_mode = false;
         $this->debug_mode = false;
 
         if ($queryString !== null) {
             $this->disable_mode = strpos($queryString, 'wovnDisable') !== false;
-            if ($store->settings['debug_mode']) {
+            // error_log("Debug mode enable: " . $debugModeEnable);
+            if ($debugModeEnable) {
                 $this->cache_disable_mode = strpos($queryString, 'wovnCacheDisable') !== false;
                 $this->debug_mode = strpos($queryString, 'wovnDebugMode') !== false;
             }
         }
         
-        error_log($this->disable_mode);
-        error_log($this->cache_disable_mode);
-        error_log($this->debug_mode);
-
-
-        // TRANSLATE THIS TO PHP
-        // String query = ((HttpServletRequest)request).getQueryString();
-        // if (query != null) {
-        //     this.disableMode = query.matches("(.*)wovnDisable(.*)");
-        //     if (settings.debugMode) {
-        //         this.cacheDisableMode = query.matches("(.*)wovnCacheDisable(.*)");
-        //         this.debugMode = query.matches("(.*)wovnDebugMode(.*)");
-        //     }
-        // }
+        // error_log("Disable mode:        " . $this->disable_mode);
+        // error_log("Cache disable mode:  " . $this->cache_disable_mode);
+        // error_log("Debug mode:          " . $this->debug_mode);
     }
 
     public function getDisableMode()

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -110,7 +110,8 @@ class Store
             // without knowing much about this feature, no one should use this.
             'save_memory_by_sending_wovn_ignore_content' => false,
             'enable_wovn_diagnostics' => false,
-            'use_cookie_lang' => false
+            'use_cookie_lang' => false,
+            'wovn_debug_mode' => false
         );
     }
 

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -12,6 +12,7 @@ require_once 'src/wovnio/wovnphp/Store.php';
 require_once 'src/wovnio/wovnphp/Headers.php';
 require_once 'src/wovnio/wovnphp/Lang.php';
 require_once 'src/wovnio/wovnphp/Url.php';
+require_once 'src/wovnio/wovnphp/RequestOptions.php';
 require_once 'src/wovnio/html/HtmlConverter.php';
 require_once 'src/wovnio/html/HtmlReplaceMarker.php';
 require_once 'src/wovnio/utils/request_handlers/RequestHandlerFactory.php';
@@ -92,8 +93,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_path_request');
         $body = '<html></html>';
         $expected_api_url = $this->getExpectedApiUrl($store, $headers, $body);
+        $request_options = new requestOptions('', false);
 
-        $this->assertTrue(API::url($store, $headers, $body) === $expected_api_url);
+        $this->assertTrue(API::url($store, $headers, $body, $request_options) === $expected_api_url);
     }
 
     public function testTranslate()
@@ -104,8 +106,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals($responsed_html, $result);
         $this->assertEquals(1, count($mock->arguments));
@@ -127,8 +130,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -147,8 +151,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = "<html><head></head><body><h1>response from html-swapper</h1></body></html>";
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -166,8 +171,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals('<html><head></head><body><h1 wovn-ignore>en</h1>Bonjour</body></html>', $result);
         $this->assertEquals(1, count($mock->arguments));
@@ -185,8 +191,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals('<html><head></head><body><h1 data-wovn-ignore>en</h1>Bonjour</body></html>', $result);
         $this->assertEquals(1, count($mock->arguments));
@@ -204,8 +211,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head><script><!-- __wovn-backend-ignored-key-0 --></script></head><body><h1>fr</h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -227,8 +235,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -251,9 +260,10 @@ class APITest extends \PHPUnit_Framework_TestCase
         '<body><h1 wovn-ignore>en</h1></body>' .
         '</html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
-
         $mock = $this->mockTranslationApi($response);
-        $result = API::translate($store, $headers, $original_html);
+        $request_options = new requestOptions('', false);
+
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -272,8 +282,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];
@@ -290,8 +301,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = null;
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async></script></head><body><h1>en</h1></body></html>';
@@ -309,8 +321,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(0, count($mock->arguments), 'dont request to translation');
         $expected_result = '<html><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script></head><body><h1>en</h1></body></html>';
         $this->assertEquals($expected_result, $result, "should return contents without fallback");
@@ -327,8 +340,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(1, count($mock->arguments));
         $expected_result = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $this->assertEquals($expected_result, $result, 'should return contents from html-swapper even if target language is same as default language');
@@ -342,8 +356,9 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
+        $request_options = new requestOptions('', false);
 
-        $result = API::translate($store, $headers, $original_html);
+        $result = API::translate($store, $headers, $original_html, $request_options);
 
         $this->assertEquals(1, count($mock->arguments));
         list($method, $url, $data, $timeout) = $mock->arguments[0];

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -24,6 +24,7 @@ use Wovnio\Test\Helpers\StoreAndHeadersFactory;
 
 use Wovnio\Wovnphp\API;
 use Wovnio\Wovnphp\Utils;
+use Wovnio\Wovnphp\RequestOptions;
 use Wovnio\Utils\RequestHandlers\RequestHandlerFactory;
 
 class APITest extends \PHPUnit_Framework_TestCase

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -97,7 +97,7 @@ class APITest extends \PHPUnit_Framework_TestCase
     {
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_path_request');
         $body = '<html></html>';
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
         $expected_api_url = $this->getExpectedApiUrl($store, $headers, $body, $request_options);
 
         $this->assertTrue(API::url($store, $headers, $body, $request_options) === $expected_api_url);
@@ -107,10 +107,8 @@ class APITest extends \PHPUnit_Framework_TestCase
     {
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_path_request');
         $body = '<html></html>';
-        $request_options = new RequestOptions('/?wovnCacheDisable', true);
+        $request_options = new RequestOptions(array('wovnCacheDisable' => ''), true);
         $expected_api_url = $this->getExpectedApiUrl($store, $headers, $body, $request_options);
-        error_log("Expected: " . $expected_api_url);
-        error_log("Actual  : " . API::url($store, $headers, $body, $request_options));
 
         $this->assertTrue(API::url($store, $headers, $body, $request_options) === $expected_api_url);
     }
@@ -123,7 +121,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -147,7 +145,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -168,7 +166,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = "<html><head></head><body><h1>response from html-swapper</h1></body></html>";
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -188,7 +186,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -208,7 +206,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -228,7 +226,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head><script><!-- __wovn-backend-ignored-key-0 --></script></head><body><h1>fr</h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -252,7 +250,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -278,7 +276,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         '</html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -299,7 +297,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -318,7 +316,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = null;
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -338,7 +336,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(0, count($mock->arguments), 'dont request to translation');
@@ -357,7 +355,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(1, count($mock->arguments));
@@ -373,7 +371,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions('', false);
+        $request_options = new RequestOptions([], false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -136,6 +136,26 @@ class APITest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1.0, $timeout);
     }
 
+    public function testTranslateWithDebugMode()
+    {
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
+
+        $original_html = '<html><head></head><body><h1>en</h1></body></html>';
+        $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
+        $response = json_encode(array("body" => $responsed_html));
+        $mock = $this->mockTranslationApi($response);
+        $request_options = new RequestOptions(array('wovnDebugMode' => ''), true);
+
+        $result = API::translate($store, $headers, $original_html, $request_options);
+
+        $this->assertEquals(1, count($mock->arguments));
+        list($method, $url, $data, $timeout) = $mock->arguments[0];
+        $this->assertEquals($this->getExpectedApiUrl($store, $headers, $original_html, $request_options), $url);
+        $expected_head_content = $this->getExpectedHtmlHeadContent($store, $headers);
+        $expected_html_before_send = "<html><head>$expected_head_content</head><body><h1>en</h1></body></html>";
+        $this->assertEquals($this->getExpectedData($store, $headers, $expected_html_before_send, array('debug_mode' => 'true')), $data);
+    }
+
     public function testTranslateWithNoindexLangs()
     {
         $settings = array('no_index_langs' => array('en'));

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -97,7 +97,7 @@ class APITest extends \PHPUnit_Framework_TestCase
     {
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_path_request');
         $body = '<html></html>';
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
         $expected_api_url = $this->getExpectedApiUrl($store, $headers, $body, $request_options);
 
         $this->assertTrue(API::url($store, $headers, $body, $request_options) === $expected_api_url);
@@ -121,7 +121,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -165,7 +165,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -186,7 +186,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = "<html><head></head><body><h1>response from html-swapper</h1></body></html>";
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -206,7 +206,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -226,7 +226,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -246,7 +246,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head><script><!-- __wovn-backend-ignored-key-0 --></script></head><body><h1>fr</h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -270,7 +270,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -296,7 +296,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         '</html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -317,7 +317,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -336,7 +336,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = null;
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -356,7 +356,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(0, count($mock->arguments), 'dont request to translation');
@@ -375,7 +375,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(1, count($mock->arguments));
@@ -391,7 +391,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new RequestOptions([], false);
+        $request_options = new RequestOptions(array(), false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -93,7 +93,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_path_request');
         $body = '<html></html>';
         $expected_api_url = $this->getExpectedApiUrl($store, $headers, $body);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $this->assertTrue(API::url($store, $headers, $body, $request_options) === $expected_api_url);
     }
@@ -106,7 +106,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -130,7 +130,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -151,7 +151,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = "<html><head></head><body><h1>response from html-swapper</h1></body></html>";
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -171,7 +171,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -191,7 +191,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1 data-wovn-ignore><!-- __wovn-backend-ignored-key-0 --></h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -211,7 +211,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head><script><!-- __wovn-backend-ignored-key-0 --></script></head><body><h1>fr</h1>Bonjour</body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -235,7 +235,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
         $response = json_encode(array("body" => $responsed_html));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -261,7 +261,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         '</html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -282,7 +282,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -301,7 +301,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = null;
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 
@@ -321,7 +321,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(0, count($mock->arguments), 'dont request to translation');
@@ -340,7 +340,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array("body" => '<html><head></head><body><h1>response from html-swapper</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
         $this->assertEquals(1, count($mock->arguments));
@@ -356,7 +356,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $original_html = '<html><head></head><body><h1>en</h1></body></html>';
         $response = json_encode(array('missingBodyError' => '<html><head></head><body><h1>fr</h1></body></html>'));
         $mock = $this->mockTranslationApi($response);
-        $request_options = new requestOptions('', false);
+        $request_options = new RequestOptions('', false);
 
         $result = API::translate($store, $headers, $original_html, $request_options);
 

--- a/test/unit/RequestOptionsTest.php
+++ b/test/unit/RequestOptionsTest.php
@@ -7,9 +7,9 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase
 {
     public function testNoOptions()
     {
-        $query_string = '/?lang=ja';
+        parse_str('/?lang=ja', $query_string_array);
         $debug_mode = true;
-        $options = new RequestOptions($query_string, $debug_mode);
+        $options = new RequestOptions($query_string_array, $debug_mode);
 
         $this->assertEquals(false, $options->getDisableMode());
         $this->assertEquals(false, $options->getCacheDisableMode());
@@ -18,9 +18,9 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase
 
     public function testAllOptions()
     {
-        $query_string = '/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode';
+        parse_str('/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode', $query_string_array);
         $debug_mode = true;
-        $options = new RequestOptions($query_string, $debug_mode);
+        $options = new RequestOptions($query_string_array, $debug_mode);
 
         $this->assertEquals(true, $options->getDisableMode());
         $this->assertEquals(true, $options->getCacheDisableMode());
@@ -29,9 +29,9 @@ class RequestOptionsTest extends \PHPUnit_Framework_TestCase
 
     public function testNeedDebugModeSettingEnabledForCacheDisableAndDebugMode()
     {
-        $query_string = '/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode';
+        parse_str('/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode', $query_string_array);
         $debug_mode = false;
-        $options = new RequestOptions($query_string, $debug_mode);
+        $options = new RequestOptions($query_string_array, $debug_mode);
 
         $this->assertEquals(true, $options->getDisableMode());
         $this->assertEquals(false, $options->getCacheDisableMode());

--- a/test/unit/RequestOptionsTest.php
+++ b/test/unit/RequestOptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+namespace Wovnio\Wovnphp\Tests;
+
+use \Wovnio\Wovnphp\RequestOptions;
+
+class RequestOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNoOptions()
+    {
+        $query_string = '/?lang=ja';
+        $debug_mode = true;
+        $options = new RequestOptions($query_string, $debug_mode);
+
+        $this->assertEquals(false, $options->getDisableMode());
+        $this->assertEquals(false, $options->getCacheDisableMode());
+        $this->assertEquals(false, $options->getDebugMode());
+    }
+
+    public function testAllOptions()
+    {
+        $query_string = '/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode';
+        $debug_mode = true;
+        $options = new RequestOptions($query_string, $debug_mode);
+
+        $this->assertEquals(true, $options->getDisableMode());
+        $this->assertEquals(true, $options->getCacheDisableMode());
+        $this->assertEquals(true, $options->getDebugMode());
+    }
+
+    public function testNeedDebugModeSettingEnabledForCacheDisableAndDebugMode()
+    {
+        $query_string = '/?lang=ja&wovnDisable&wovnCacheDisable&wovnDebugMode';
+        $debug_mode = false;
+        $options = new RequestOptions($query_string, $debug_mode);
+
+        $this->assertEquals(true, $options->getDisableMode());
+        $this->assertEquals(false, $options->getCacheDisableMode());
+        $this->assertEquals(false, $options->getDebugMode());
+    }
+}


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-589

### Comments
Adds support for `wovnDisable` URL parameter which if enabled will cause the library to not swap the request.

Also adds a Debug Mode setting that enables two URL parameters:
`wovnCacheDisable`: inserts a timestamp into the API call url to circumvent Fastly caching
`wovnDebugMode`: adds {“debug_mode”: “true”} to API call request payload, and add a timestamp to the API call to circumvent Fastly cache.

Usage:
All parameters can enabled by adding to the URL either without a value (e.g. `?lang=ja&wovnCacheDisable`) or with any value other than the string `'false'` (e.g. `?lang=ja&wovnDebugMode=true`).