### PR TITLE
Fix Xdebug version at 2.9.0

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN a2enmod rewrite
 
 # install xdebug
-RUN pecl install xdebug
+RUN pecl install xdebug-2.9.0
 RUN docker-php-ext-enable xdebug
 
 WORKDIR /var/www/html

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -5,7 +5,7 @@ FROM ${DOCKER_IMAGE}
 RUN apt-get update
 
 # install xdebug
-RUN pecl install xdebug
+RUN pecl install xdebug-2.9.0
 RUN docker-php-ext-enable xdebug
 
 WORKDIR /var/www/html


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

### Comments
Fixes Xdebug version at 2.9.0.

Newer versions of Xdebug do not work with the current configuration and will result in your debugger not connecting to the test site.
### Release comments (new feature)
