### PR TITLE
[Fix]incorrect regex backref

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
@@ -20,8 +20,8 @@ class CustomDomainLangUrlHandler
                 "(${currentHostAndPath})". // 2. host and path
                 '((?:/|\?|#).*)?$' . // 3: other
                 '@';
-
-            return preg_replace($regex, "$1${newHostAndPath}$3", $absoluteUrl);
+            $replacement = '${1}' . "${newHostAndPath}" . '${3}';
+            return preg_replace($regex, $replacement, $absoluteUrl);
         }
         return $absoluteUrl;
     }

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
@@ -20,8 +20,7 @@ class CustomDomainLangUrlHandler
                 "(${currentHostAndPath})". // 2. host and path
                 '((?:/|\?|#).*)?$' . // 3: other
                 '@';
-            $replacement = '${1}' . "${newHostAndPath}" . '${3}';
-            return preg_replace($regex, $replacement, $absoluteUrl);
+            return preg_replace($regex, '${1}' . "${newHostAndPath}" . '${3}', $absoluteUrl);
         }
         return $absoluteUrl;
     }

--- a/test/unit/custom_domain/CustomDomainLangUrlHandlerTest.php
+++ b/test/unit/custom_domain/CustomDomainLangUrlHandlerTest.php
@@ -80,5 +80,6 @@ class CustomDomainLangUrlHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('zh-hant-hk.foo.com/zhtrap', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('zh-hant-hk.foo.com/zhtrap', $zh_hant_hk, $ja));
         $this->assertEquals('english.foo.com/zhtrap', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('17797-trial2.foo.com/zhtrap', $pt, $en));
+        $this->assertEquals('17797-trial2.foo.com/zhtrap', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('17797-trial2.foo.com/zhtrap', $pt, $pt));
     }
 }

--- a/test/unit/custom_domain/CustomDomainLangUrlHandlerTest.php
+++ b/test/unit/custom_domain/CustomDomainLangUrlHandlerTest.php
@@ -19,7 +19,8 @@ class CustomDomainLangUrlHandlerTest extends \PHPUnit_Framework_TestCase
             'ja' => array('url' => 'foo.com/path'),
             'zh-CHS' => array('url' => 'foo.com/dir/path'),
             'en' => array('url' => 'english.foo.com/'),
-            'zh-Hant-HK' => array('url' => 'zh-hant-hk.foo.com/zh')
+            'zh-Hant-HK' => array('url' => 'zh-hant-hk.foo.com/zh'),
+            'pt' => array('url' => '17797-trial2.foo.com/')
         );
         $this->customDomainLangs = new CustomDomainLangs($this->customDomainLangsSetting, 'en');
     }
@@ -55,6 +56,7 @@ class CustomDomainLangUrlHandlerTest extends \PHPUnit_Framework_TestCase
         $zh_chs = $this->customDomainLangs->getCustomDomainLangByLang('zh-CHS');
         $en = $this->customDomainLangs->getCustomDomainLangByLang('en');
         $zh_hant_hk = $this->customDomainLangs->getCustomDomainLangByLang('zh-Hant-HK');
+        $pt = $this->customDomainLangs->getCustomDomainLangByLang('pt');
 
         $this->assertEquals('foo.com', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('foo.com', $fr, $fr));
         $this->assertEquals('foo.com/path', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('foo.com', $fr, $ja));
@@ -77,5 +79,6 @@ class CustomDomainLangUrlHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.com/path/path/index.html#hash', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('zh-hant-hk.foo.com/zh/path/index.html#hash', $zh_hant_hk, $ja));
 
         $this->assertEquals('zh-hant-hk.foo.com/zhtrap', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('zh-hant-hk.foo.com/zhtrap', $zh_hant_hk, $ja));
+        $this->assertEquals('english.foo.com/zhtrap', CustomDomainLangUrlHandler::changeToNewCustomDomainLang('17797-trial2.foo.com/zhtrap', $pt, $en));
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
In CustomDomainUrlHandler.php, a back-reference is used to replace part of the URL. 

Originally, it was. `"$1${replacement}$3"`. This works fine in most situations (how is this even possible?). But when the URL starts with the number `1`, that `1` will be incorrectly removed.

e.g. `https://123.test.com` -> `https://23.replacement.com` (NG)

Now, the new back-reference is in the `${1}` and `${3}` format.

### Comments

### Release comments (new feature)
