### PR TITLE
[Fix] Change use of SERVER_NAME to HTTP_HOST

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -112,7 +112,7 @@ class Headers
             if ($this->store->settings['use_proxy'] && isset($this->env['HTTP_X_FORWARDED_HOST'])) {
                 $server_name = $this->env['HTTP_X_FORWARDED_HOST'];
             } else {
-                $server_name = $this->env['SERVER_NAME'];
+                $server_name = $this->env['HTTP_HOST'];
             }
             // get the lang in the path
             if ($this->store->settings['use_proxy'] && isset($this->env['HTTP_X_FORWARDED_REQUEST_URI'])) {

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -335,6 +335,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         foreach ($testCases as $case) {
             list($serverName, $expectedLangCode) = $case;
             $mergedEnv = array_merge($env, array('SERVER_NAME' => $serverName));
+            $mergedEnv = array_merge($mergedEnv, array('HTTP_HOST' => $serverName));
             list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $mergedEnv);
 
             $this->assertEquals('subdomain', $store->settings['url_pattern_name']);
@@ -356,26 +357,26 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
             'custom_domain_langs' => $custom_domain_langs
         );
         $testCases = array(
-            array(array('SERVER_NAME' => 'my-site.com', 'REQUEST_URI' => '/'), 'en'),
-            array(array('SERVER_NAME' => 'en-us.my-site.com', 'REQUEST_URI' => '/'), 'en-US'),
-            array(array('SERVER_NAME' => 'my-site.com', 'REQUEST_URI' => '/ja'), 'ja'),
-            array(array('SERVER_NAME' => 'my-site.com', 'REQUEST_URI' => '/zh/chs'), 'zh-CHS'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'my-site.com', 'REQUEST_URI' => '/'), 'en'),
+            array(array('HTTP_HOST' => 'en-us.my-site.com', 'REQUEST_URI' => '/'), 'en-US'),
+            array(array('HTTP_HOST' => 'my-site.com', 'REQUEST_URI' => '/ja'), 'ja'),
+            array(array('HTTP_HOST' => 'my-site.com', 'REQUEST_URI' => '/zh/chs'), 'zh-CHS'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh'), 'zh-Hant-HK'),
 
             // request uri pattern
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.html'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir/'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir/index.html'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh?query=1'), 'zh-Hant-HK'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh#hash'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.html'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir/'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/dir/index.html'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh?query=1'), 'zh-Hant-HK'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh#hash'), 'zh-Hant-HK'),
 
             // should be default lang
-            array(array('SERVER_NAME' => 'my-site.com', 'REQUEST_URI' => '/japan'), 'en'),
-            array(array('SERVER_NAME' => 'my-site.com', 'REQUEST_URI' => '/'), 'en'),
-            array(array('SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/'), '')
+            array(array('HTTP_HOST' => 'my-site.com', 'REQUEST_URI' => '/japan'), 'en'),
+            array(array('HTTP_HOST' => 'my-site.com', 'REQUEST_URI' => '/'), 'en'),
+            array(array('HTTP_HOST' => 'zh-hant-hk.com', 'REQUEST_URI' => '/'), '')
         );
 
         foreach ($testCases as $case) {
@@ -431,6 +432,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         );
         $env = array(
             'SERVER_NAME' => 'ja.wovn.io',
+            'HTTP_HOST' => 'ja.wovn.io',
             'REQUEST_URI' => '/ko/path/index.html',
             'HTTP_X_FORWARDED_HOST' => 'en.minimaltech.co',
             'HTTP_X_FORWARDED_REQUEST_URI' => '/sv/path/index.html'
@@ -631,6 +633,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $env = array(
             'HTTP_REFERER' => 'ja.minimaltech.co',
             'SERVER_NAME' => 'ja.minimaltech.co',
+            'HTTP_HOST' => 'ja.minimaltech.co',
             'REQUEST_URI' => '/dummy'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('japanese_subdomain_request', $settings, $env);

--- a/test/unit/UrlTest.php
+++ b/test/unit/UrlTest.php
@@ -1016,39 +1016,39 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             // $target_uri, $lang, $expected_uri, $env
             // absolute URL
             array('https://my-site.com', 'en', 'https://my-site.com', array()),
-            array('https://my-site.com/ja', 'ja', 'https://my-site.com', array()),
-            array('https://my-site.com/ja/index.php', 'ja', 'https://my-site.com/index.php', array()),
-            array('https://my-site.com/ja/a/b/', 'ja', 'https://my-site.com/a/b/', array()),
-            array('https://my-site.com/ja/a/b/index.php', 'ja', 'https://my-site.com/a/b/index.php', array()),
-            array('https://en-us.my-site.com/index.php', 'en-US', 'https://my-site.com/index.php', array()),
-            array('https://my-site.com/zh/chs/index.php', 'zh-CHS', 'https://my-site.com/index.php', array()),
-            array('https://zh-hant-hk.com/zh/index.php', 'zh-Hant-HK', 'https://my-site.com/index.php', array()),
-            array('https://zh-hant-hk.com/zh/index.php?a=1&b=2', 'zh-Hant-HK', 'https://my-site.com/index.php?a=1&b=2', array()),
-            array('https://zh-hant-hk.com/zh/index.php#hash', 'zh-Hant-HK', 'https://my-site.com/index.php#hash', array()),
-            array('https://zh-hant-hk.com/zh/index.php?a=1&b=2#hash', 'zh-Hant-HK', 'https://my-site.com/index.php?a=1&b=2#hash', array()),
+            array('https://my-site.com/ja', 'ja', 'https://my-site.com', array('REQUEST_URI' => '/ja')),
+            array('https://my-site.com/ja/index.php', 'ja', 'https://my-site.com/index.php', array('REQUEST_URI' => '/ja/index.php')),
+            array('https://my-site.com/ja/a/b/', 'ja', 'https://my-site.com/a/b/', array('REQUEST_URI' => '/ja/a/b/')),
+            array('https://my-site.com/ja/a/b/index.php', 'ja', 'https://my-site.com/a/b/index.php', array('REQUEST_URI' => '/ja/a/b/index.php')),
+            array('https://en-us.my-site.com/index.php', 'en-US', 'https://my-site.com/index.php', array('HTTP_HOST' => 'en-us.my-site.com', 'SERVER_NAME' => 'en-us.my-site.com', 'REQUEST_URI' => '/index.php')),
+            array('https://my-site.com/zh/chs/index.php', 'zh-CHS', 'https://my-site.com/index.php', array('REQUEST_URI' => '/zh/chs/index.php')),
+            array('https://zh-hant-hk.com/zh/index.php', 'zh-Hant-HK', 'https://my-site.com/index.php', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('https://zh-hant-hk.com/zh/index.php?a=1&b=2', 'zh-Hant-HK', 'https://my-site.com/index.php?a=1&b=2', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('https://zh-hant-hk.com/zh/index.php#hash', 'zh-Hant-HK', 'https://my-site.com/index.php#hash', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('https://zh-hant-hk.com/zh/index.php?a=1&b=2#hash', 'zh-Hant-HK', 'https://my-site.com/index.php?a=1&b=2#hash', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
 
             // absolute path
             array('/', 'en', '/', array()),
-            array('/ja/', 'ja', '/', array()),
-            array('/ja/index.php', 'ja', '/index.php', array()),
-            array('/ja/a/b/', 'ja', '/a/b/', array()),
-            array('/ja/a/b/index.php', 'ja', '/a/b/index.php', array()),
-            array('/index.php', 'en-US', '/index.php', array('HTTP_HOST' => 'en-us.my-site.com')),
-            array('/zh/chs/index.php', 'zh-CHS', '/index.php', array()),
-            array('/zh/index.php', 'zh-Hant-HK', '/index.php', array('HTTP_HOST' => 'zh-hant-hk.com')),
-            array('/zh/index.php?a=1&b=2', 'zh-Hant-HK', '/index.php?a=1&b=2', array('HTTP_HOST' => 'zh-hant-hk.com')),
-            array('/zh/index.php#hash', 'zh-Hant-HK', '/index.php#hash', array('HTTP_HOST' => 'zh-hant-hk.com')),
-            array('/zh/index.php?a=1&b=2#hash', 'zh-Hant-HK', '/index.php?a=1&b=2#hash', array('HTTP_HOST' => 'zh-hant-hk.com')),
+            array('/ja/', 'ja', '/', array('REQUEST_URI' => '/ja')),
+            array('/ja/index.php', 'ja', '/index.php', array('REQUEST_URI' => '/ja/index.php')),
+            array('/ja/a/b/', 'ja', '/a/b/', array('REQUEST_URI' => '/ja/a/b/')),
+            array('/ja/a/b/index.php', 'ja', '/a/b/index.php', array('REQUEST_URI' => '/ja/a/b/index.php')),
+            array('/index.php', 'en-US', '/index.php', array('HTTP_HOST' => 'en-us.my-site.com', 'SERVER_NAME' => 'en-us.my-site.com', 'REQUEST_URI' => '/index.php')),
+            array('/zh/chs/index.php', 'zh-CHS', '/index.php', array('REQUEST_URI' => '/zh/chs/index.php')),
+            array('/zh/index.php', 'zh-Hant-HK', '/index.php', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('/zh/index.php?a=1&b=2', 'zh-Hant-HK', '/index.php?a=1&b=2', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('/zh/index.php#hash', 'zh-Hant-HK', '/index.php#hash', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
+            array('/zh/index.php?a=1&b=2#hash', 'zh-Hant-HK', '/index.php?a=1&b=2#hash', array('HTTP_HOST' => 'zh-hant-hk.com', 'SERVER_NAME' => 'zh-hant-hk.com', 'REQUEST_URI' => '/zh/index.php')),
 
             // other patterns should be keep original
-            array('a=1&b=2', 'zh-Hant-HK', 'a=1&b=2', array()),
-            array('#hash', 'zh-Hant-HK', '#hash', array())
+            array('a=1&b=2', 'en-US', 'a=1&b=2', array('HTTP_HOST' => 'en-us.my-site.com', 'SERVER_NAME' => 'en-us.my-site.com', 'REQUEST_URI' => '/')),
+            array('#hash', 'en-US', '#hash', array('HTTP_HOST' => 'en-us.my-site.com', 'SERVER_NAME' => 'en-us.my-site.com', 'REQUEST_URI' => '/'))
         );
 
         $settings = array(
             'project_token' => 'T0k3N',
             'default_lang' =>  'en',
-            'supported_langs' => array('en'),
+            'supported_langs' => array('en', 'en-US', 'ja', 'zh-CHS', 'zh-Hant-HK'),
             'url_pattern_name' => 'custom_domain',
             'custom_domain_langs' => $custom_domain_langs
         );
@@ -1062,7 +1062,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             $additional_env = empty($env) ? $base_env : array_merge($base_env, $env);
             list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $additional_env);
 
-            $this->assertEquals('en', $headers->requestLang());
+            $this->assertEquals($lang, $headers->requestLang());
             $this->assertEquals($expected_uri, Url::removeLangCode($target_uri, $lang, $store, $headers), "target_url->[{$target_uri}] lang->[{$lang}] expected_uri->[{$expected_uri}]");
         }
     }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
This PR fixes an issue where the host name of a request cannot be reliably determined when determining the request language.

### Comments
Originally the server environment variable `SERVER_NAME` is used to determine the host name of a request, and this host name is subsequently used to reconstruct a URL for later processing. When a user is using some cgi interfaces, there is a chance that `SERVER_NAME` does not reflect the actual host name.

To fix this, `HTTP_HOST` is used instead, which always reflects the `Host` header of the incoming request. This should be a much more reliable way of determining the host name.

### Release comments (new feature)
