### PR TITLE
Fixed logger default behavior: logger is now off by default unless logging is set.

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -801,7 +801,7 @@ Configures WOVN.php's internal logging. When this section is included in `wovn.j
 
 `max_line_length`: Optional, defaults to `1024`. Lines longer than this setting will be truncated.
 
-`wovn.json` ONLY
+`wovn.json`
 
 ```json
 {
@@ -811,6 +811,14 @@ Configures WOVN.php's internal logging. When this section is included in `wovn.j
     "max_line_length": 5124
   }
 }
+```
+
+`wovn.ini`
+
+```ini
+logging[destination] = "file"
+logging[path] = "/var/logs/error_log.log"
+logging[max_line_length] = 5124
 ```
 
 ## 4. Environment Variable

--- a/README.en.md
+++ b/README.en.md
@@ -805,9 +805,11 @@ Configures WOVN.php's internal logging. When this section is included in `wovn.j
 
 ```json
 {
-  "destination": "file",
-  "path": "/var/logs/error_log.log",
-  "max_line_length": 5124
+  "logging": {
+    "destination": "file",
+    "path": "/var/logs/error_log.log",
+    "max_line_length": 5124
+  }
 }
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -791,6 +791,26 @@ use_cookie_lang = true
 }
 ```
 
+#### `logging`
+
+Configures WOVN.php's internal logging. When this section is included in `wovn.json`, WOVN.php's internal logging is enabled. WOVN.php's internal logging uses `error_log()` to log its messages.
+
+`destination`: Optional, can only have the value of `file`. If this is set, WOVN.php's logs will be written into a file defined by `path`. If this not set, logs will be written to PHP's default handling location of `error_log`.
+
+`path`: Required if `destination` is set. Configures which file WOVN.php's logs will be written to. Must be a fully qualified path.
+
+`max_line_length`: Optional, defaults to `1024`. Lines longer than this setting will be truncated.
+
+`wovn.json` ONLY
+
+```json
+{
+  "destination": "file",
+  "path": "/var/logs/error_log.log",
+  "max_line_length": 5124
+}
+```
+
 ## 4. Environment Variable
 
 ### `WOVN_TARGET_LANG`

--- a/src/wovnio/wovnphp/Logger.php
+++ b/src/wovnio/wovnphp/Logger.php
@@ -33,7 +33,7 @@ class Logger
         self::$logger = $logger;
     }
 
-    public function __construct($quiet = false, $prefix = 'WOVN.php')
+    public function __construct($quiet = true, $prefix = 'WOVN.php')
     {
         date_default_timezone_set('UTC');
         $this->prefix = $prefix;

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -198,6 +198,7 @@ class Store
             if (!empty($this->settings['logging']['max_line_length'])) {
                 Logger::get()->setMaxLogLineLength($this->settings['logging']['max_line_length']);
             }
+            Logger::get()->setQuiet(false);
         }
 
         if (!is_bool($this->settings['insert_hreflangs'])) {


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
This PR aims to fix a bug where WOVN.php's logger always outputs logs to PHP's system logger, even if no `logging` setting is configured in the config file.

### Comments
**Old behavior:**
The Wovn logger is always set to active upon initialization, with default destination as PHP System Logger.

**New behavior:**
the Wovn logger is only set to active if `logging` setting is configured in the config file.

### Release comments (new feature)
This PR does not introduce new behaviors and is backward compatible.