### PR TITLE
Feature/add support for port numbers

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -308,6 +308,8 @@ NOT SUPPORTED
 }
 ```
 
+*New in 1.8.4*: `url` can contain a port number, e.g. `www.site.com:8081/english`.
+
 For the example above, all request URLs that match `www.site.com/english/*` will be considered as requests in English language.
 All request URLs other than the above that match `www.site.co.jp/*` will be considered as requests in Japanese langauge.
 And, request URLs that match `fr.site.co.jp/*` will be considered as requests in French langauge.

--- a/README.en.md
+++ b/README.en.md
@@ -308,8 +308,6 @@ NOT SUPPORTED
 }
 ```
 
-*New in 1.8.4*: `url` can contain a port number, e.g. `www.site.com:8081/english`.
-
 For the example above, all request URLs that match `www.site.com/english/*` will be considered as requests in English language.
 All request URLs other than the above that match `www.site.co.jp/*` will be considered as requests in Japanese langauge.
 And, request URLs that match `fr.site.co.jp/*` will be considered as requests in French langauge.

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.4';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.4-preview';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.3';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.8.4';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLang.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLang.php
@@ -40,6 +40,9 @@ class CustomDomainLang
   
     public function isMatch($parsedUrl)
     {
+        if (isset($parsedUrl['port'])) {
+            $parsedUrl['host'] = $parsedUrl['host'] . ':' . $parsedUrl['port'];
+        }
         $host = $parsedUrl['host'];
         $path = array_key_exists('path', $parsedUrl) ? $parsedUrl['path'] : '/';
         return strtolower($host) === strtolower($this->host) && $this->pathIsEqualOrSubsetOf($this->path, $path);

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangSource.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangSource.php
@@ -9,6 +9,9 @@ class CustomDomainLangSource extends CustomDomainLang
     {
         $url = preg_match("/https?:\/\//", $url, $matches) ? $url : 'http://' . $url;
         $parsedUrl = parse_url($url);
+        if (isset($parsedUrl['port'])) {
+            $parsedUrl['host'] = $parsedUrl['host'] . ':' . $parsedUrl['port'];
+        }
         $path = isset($parsedUrl['path']) ? $parsedUrl['path'] : '/';
         parent::__construct($parsedUrl['host'], $path, $lang);
     }

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
@@ -82,7 +82,14 @@ class CustomDomainLangs
     {
         $currentLangDomainLang = $this->getSourceCustomDomainByLang($lang);
         $defaultCustomDomainLang = $this->getCustomDomainLangByLang($defaultLang);
-        return CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
+        $virtualUrl = CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
+        return $this->removePort($virtualUrl);
+    }
+
+    private function removePort($url)
+    {
+        $parsed = parse_url($this->addProtocolIfNeeded($url));
+        return $parsed['scheme'] . '://' . $parsed['host'] . $parsed['path'];
     }
 
     // parse_url needs protocol to parse URL.

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
@@ -82,20 +82,13 @@ class CustomDomainLangs
     {
         $currentLangDomainLang = $this->getSourceCustomDomainByLang($lang);
         $defaultCustomDomainLang = $this->getCustomDomainLangByLang($defaultLang);
-        $virtualUrl = CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
-        return $this->removePort($virtualUrl);
+        return CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
     }
 
     // parse_url needs protocol to parse URL.
     private function addProtocolIfNeeded($url)
     {
         return preg_match("/https?:\/\//", $url, $matches) ? $url : 'http://' . $url;
-    }
-
-    private function removePort($url)
-    {
-        $parsed = parse_url($this->addProtocolIfNeeded($url));
-        return $parsed['scheme'] . '://' . $parsed['host'] . $parsed['path'];
     }
 
     private static function getDefaultLangCustomDomain($customDomainLangsSettingsArray, $defaultLang)

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
@@ -94,7 +94,7 @@ class CustomDomainLangs
 
     private function removePort($url)
     {
-        $parsed = parse_url($url);
+        $parsed = parse_url($this->addProtocolIfNeeded($url));
         return $parsed['scheme'] . '://' . $parsed['host'] . $parsed['path'];
     }
 

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
@@ -15,7 +15,9 @@ class CustomDomainLangs
         foreach ($customDomainLangsSettingsArray as $langCode => $config) {
             $parsedUrl = parse_url($this->addProtocolIfNeeded($config['url']));
             $source = array_key_exists('source', $config) ? $config['source'] : $defaultLangCustomDomain;
-
+            if (isset($parsedUrl['port'])) {
+                $parsedUrl['host'] = $parsedUrl['host'] . ':' . $parsedUrl['port'];
+            }
             // Disable notice error by adding @, when path is not defined
             $this->customDomainLangs[$langCode] = new CustomDomainLang($parsedUrl['host'], @$parsedUrl['path'], $langCode, $source);
         }

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangs.php
@@ -82,13 +82,20 @@ class CustomDomainLangs
     {
         $currentLangDomainLang = $this->getSourceCustomDomainByLang($lang);
         $defaultCustomDomainLang = $this->getCustomDomainLangByLang($defaultLang);
-        return CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
+        $virtualUrl = CustomDomainLangUrlHandler::changeToNewCustomDomainLang($physicalUri, $currentLangDomainLang, $defaultCustomDomainLang);
+        return $this->removePort($virtualUrl);
     }
 
     // parse_url needs protocol to parse URL.
     private function addProtocolIfNeeded($url)
     {
         return preg_match("/https?:\/\//", $url, $matches) ? $url : 'http://' . $url;
+    }
+
+    private function removePort($url)
+    {
+        $parsed = parse_url($url);
+        return $parsed['scheme'] . '://' . $parsed['host'] . $parsed['path'];
     }
 
     private static function getDefaultLangCustomDomain($customDomainLangsSettingsArray, $defaultLang)

--- a/test/unit/custom_domain/CustomDomainLangTest.php
+++ b/test/unit/custom_domain/CustomDomainLangTest.php
@@ -48,10 +48,10 @@ class CustomDomainLangTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->customDomainRootPath->isMatch(parse_url('http://otherdomain.com/other/test.html')));
     }
 
-    public function testIsMatchWithDifferentPortNumberShouldBeIgnored()
+    public function testIsMatchShouldNotMatchDifferentPorts()
     {
-        $this->assertTrue($this->customDomainRootPath->isMatch(parse_url('http://foo.com:3000/other/test.html')));
-        $this->assertTrue($this->customDomainRootPath->isMatch(parse_url('http://foo.com:80/other/test.html')));
+        $this->assertFalse($this->customDomainRootPath->isMatch(parse_url('http://foo.com:3000/other/test.html')));
+        $this->assertFalse($this->customDomainRootPath->isMatch(parse_url('http://foo.com:80/other/test.html')));
         $this->assertTrue($this->customDomainRootPath->isMatch(parse_url('http://foo.com/other/test.html')));
     }
 

--- a/test/unit/custom_domain/CustomDomainLangTest.php
+++ b/test/unit/custom_domain/CustomDomainLangTest.php
@@ -18,6 +18,7 @@ class CustomDomainLangTest extends \PHPUnit_Framework_TestCase
         $this->customDomainWithPathNoTrailingSlash = new CustomDomainLang('foo.com', '/path', 'fr');
         $this->customDomainWithPathTrailingSlash = new CustomDomainLang('foo.com', '/path/', 'fr');
         $this->customDomainPathEncodedSpaces = new CustomDomainLang('foo.com', '/dir%20path', 'fr');
+        $this->customDomainWithPort = new CustomDomainLang('foo.com:8099', '/path', 'fr');
     }
 
     public function testCustomDomainLangParams()
@@ -53,6 +54,12 @@ class CustomDomainLangTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->customDomainRootPath->isMatch(parse_url('http://foo.com:3000/other/test.html')));
         $this->assertFalse($this->customDomainRootPath->isMatch(parse_url('http://foo.com:80/other/test.html')));
         $this->assertTrue($this->customDomainRootPath->isMatch(parse_url('http://foo.com/other/test.html')));
+    }
+
+    public function testIsMatchShouldMatchSamePort()
+    {
+        $this->assertTrue($this->customDomainWithPort->isMatch(parse_url('http://foo.com:8099/path')));
+        $this->assertTrue($this->customDomainWithPort->isMatch(parse_url('http://foo.com:8099/path/more')));
     }
 
     public function testIsMatchWithDomainContainingSubstringShouldBeFalse()

--- a/test/unit/custom_domain/CustomDomainLangsTest.php
+++ b/test/unit/custom_domain/CustomDomainLangsTest.php
@@ -129,7 +129,7 @@ class CustomDomainLangsTest extends \PHPUnit_Framework_TestCase
     {
         $currentUri = "http://no.foo.com:8000/blog/entry1.html";
         $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "no", "fi");
-        $expectedComputedUri = "http://fii.com:8000/path/blog/entry1.html";
+        $expectedComputedUri = "http://fii.com/path/blog/entry1.html";
         $this->assertEquals($expectedComputedUri, $computedUri);
     }
 }

--- a/test/unit/custom_domain/CustomDomainLangsTest.php
+++ b/test/unit/custom_domain/CustomDomainLangsTest.php
@@ -20,6 +20,7 @@ class CustomDomainLangsTest extends \PHPUnit_Framework_TestCase
             'zh-CHS' => array('url' => 'foo.com/dir/path'),
             'en' => array('url' => 'english.foo.com/', 'source' => 'global.foo.com/'),
             'no' => array('url' => 'foo.com:8000/path', 'source' => 'no.foo.com:8000/'),
+            'fi' => array('url' => 'fii.com:8000/path', 'source' => 'fi.foo.com:8000/'),
         );
         $this->customDomainLangs = new CustomDomainLangs($this->customDomainLangsSetting, 'en');
     }
@@ -124,11 +125,11 @@ class CustomDomainLangsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedComputedUri, $computedUri);
     }
 
-    public function testComputeSourceVirtualUrlShouldRemovePortNumber()
+    public function testComputeSourceVirtualUrlShouldNotRemovePortNumber()
     {
         $currentUri = "http://no.foo.com:8000/blog/entry1.html";
-        $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "no", "en");
-        $expectedComputedUri = "http://english.foo.com/blog/entry1.html";
+        $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "no", "fi");
+        $expectedComputedUri = "http://fii.com:8000/path/blog/entry1.html";
         $this->assertEquals($expectedComputedUri, $computedUri);
     }
 }

--- a/test/unit/custom_domain/CustomDomainLangsTest.php
+++ b/test/unit/custom_domain/CustomDomainLangsTest.php
@@ -18,7 +18,8 @@ class CustomDomainLangsTest extends \PHPUnit_Framework_TestCase
             'fr' => array('url' => 'foo.com/'),
             'ja' => array('url' => 'foo.com/path', 'source' => 'japan.foo.com/'),
             'zh-CHS' => array('url' => 'foo.com/dir/path'),
-            'en' => array('url' => 'english.foo.com/', 'source' => 'global.foo.com/')
+            'en' => array('url' => 'english.foo.com/', 'source' => 'global.foo.com/'),
+            'no' => array('url' => 'foo.com:8000/path', 'source' => 'no.foo.com:8000/'),
         );
         $this->customDomainLangs = new CustomDomainLangs($this->customDomainLangsSetting, 'en');
     }
@@ -109,17 +110,25 @@ class CustomDomainLangsTest extends \PHPUnit_Framework_TestCase
 
     public function testComputeSourceVirtualUrlDefaultToDefault()
     {
-        $currentUri = "global.foo.com/blog/entry1.html";
+        $currentUri = "http://global.foo.com/blog/entry1.html";
         $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "en", "en");
-        $expectedComputedUri = "english.foo.com/blog/entry1.html";
+        $expectedComputedUri = "http://english.foo.com/blog/entry1.html";
         $this->assertEquals($expectedComputedUri, $computedUri);
     }
 
     public function testComputeSourceVirtualUrlOtherToDefault()
     {
-        $currentUri = "japan.foo.com/blog/entry1.html";
+        $currentUri = "http://japan.foo.com/blog/entry1.html";
         $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "ja", "en");
-        $expectedComputedUri = "english.foo.com/blog/entry1.html";
+        $expectedComputedUri = "http://english.foo.com/blog/entry1.html";
+        $this->assertEquals($expectedComputedUri, $computedUri);
+    }
+
+    public function testComputeSourceVirtualUrlShouldRemovePortNumber()
+    {
+        $currentUri = "http://no.foo.com:8000/blog/entry1.html";
+        $computedUri = $this->customDomainLangs->computeSourceVirtualUrl($currentUri, "no", "en");
+        $expectedComputedUri = "http://english.foo.com/blog/entry1.html";
         $this->assertEquals($expectedComputedUri, $computedUri);
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/SUP-619

### Comments
Added support for port numbers in custom domain langs. Port numbers are appended to `host` in parsed urls.

Possible improvement: the code can further be simplified by providing a custom parse_url function.

### Release comments (new feature)
Custom Domain Lang patterns are now port sensitive.
