### PR TITLE
added new test pages.

### DIFF
--- a/docker/public/page.php
+++ b/docker/public/page.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta name="description" content="Some description meta." />
+    <meta charset="utf-8">
+    <title>Standard WOVN Test Page</title>
+</head>
+
+<body>
+
+<h1>Website Title (EN)</h1>
+
+<div class="container">
+    <p>This is a sample sentence.</p>
+</div>
+
+<ul>
+    <li>Item Number 1</li>
+    <li>このアイテムは意図的に日本語で書かれています</li>
+</ul>
+
+<div class="photos">
+    <p>This cat photo has alt text.</p>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Tabby_cat_with_blue_eyes-3336579.jpg/200px-Tabby_cat_with_blue_eyes-3336579.jpg" alt="a photo of a cat"></img>
+</div>
+
+<div class="invalid">
+    <potato>This text is inside an invalid HTML tag.</potato>
+</div>
+
+</body>
+</html>

--- a/docker/public/page.php
+++ b/docker/public/page.php
@@ -1,33 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta name="description" content="Some description meta." />
     <meta charset="utf-8">
     <title>Standard WOVN Test Page</title>
 </head>
-
 <body>
-
 <h1>Website Title (EN)</h1>
-
-<div class="container">
+<div>
     <p>This is a sample sentence.</p>
 </div>
-
-<ul>
-    <li>Item Number 1</li>
-    <li>このアイテムは意図的に日本語で書かれています</li>
-</ul>
-
-<div class="photos">
-    <p>This cat photo has alt text.</p>
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Tabby_cat_with_blue_eyes-3336579.jpg/200px-Tabby_cat_with_blue_eyes-3336579.jpg" alt="a photo of a cat"></img>
-</div>
-
-<div class="invalid">
-    <potato>This text is inside an invalid HTML tag.</potato>
-</div>
-
 </body>
 </html>

--- a/docker/public/redirecting_page.php
+++ b/docker/public/redirecting_page.php
@@ -2,7 +2,7 @@
 // index.php
 $host  = $_SERVER['HTTP_HOST'];
 $uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
-$extra = 'testdir/testpage-redirect-destination.php';
+$extra = 'redirection_target.php';
 header("Location: http://$host$uri/$extra");
 exit();
 ?>

--- a/docker/public/redirection_target.php
+++ b/docker/public/redirection_target.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+</head>
+
+<body>
+<h1>Redirection Target (EN)</h1>
+</body>
+</html>


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
This PR standardizes the available urls for testing. For PHP pages, they all ends in `.php`.

### Comments
The following standard URLs are made available:
- `/redirecting_page.php` : this will redirect to `/redirection_target.php`
- `/page.php` : a simple html test page

Also, the following .gitignore config doesn't do anything to allow individual files within `/docker/` be tracked...

```
/docker/*
!/docker/apache/*
!/docker/nginx/*
!/docker/HOWTO.md
!/docker/php.ini
```

from git documentaiton:

> It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined.

I'm not sure why they were added but I'm keeping them for now.
### Release comments (new feature)
