### PR TITLE
[ST-901] Added support for custom requests.

### DIFF
--- a/docker/apache.yml
+++ b/docker/apache.yml
@@ -13,10 +13,6 @@ services:
       - ./php.ini:/usr/local/etc/php/php.ini
       - ./public:/var/www/html
       - ../:/var/www/html/WOVN.php
-      - ../wovn.ini.sample:/var/www/html/wovn.ini
-      - ../wovn.json.sample:/var/www/html/wovn.json
-      - ../wovn_index_sample.php:/var/www/html/wovn_index.php
-      - ../htaccess_sample:/var/www/html/.htaccess
     networks:
       - backend-network
 networks:

--- a/docker/public/.htaccess
+++ b/docker/public/.htaccess
@@ -3,9 +3,6 @@
 RewriteEngine on
 RewriteRule ^/?(?:ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi|km|ta|si|en-US|zh-Hant-HK)($|/.*$) $1 [L]
 
-RewriteCond %{REQUEST_URI} /custom_response*
-RewriteRule "custom_response/?.*" "custom_index.php"
-
 # Intercept only static content: html and htm urls
 # Warning: do not remove this line or other content could be loaded
 RewriteCond %{REQUEST_URI} /$ [OR]

--- a/docker/public/.htaccess
+++ b/docker/public/.htaccess
@@ -1,7 +1,8 @@
-# This .htaccess file should only be used inside the testing docker envs
-
 RewriteEngine on
 RewriteRule ^/?(?:ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi|km|ta|si|en-US|zh-Hant-HK)($|/.*$) $1 [L]
+
+RewriteRule ^custom_index.php$ - [L]
+RewriteRule ^custom_response/?.* /custom_index.php [L]
 
 # Intercept only static content: html and htm urls
 # Warning: do not remove this line or other content could be loaded

--- a/docker/public/.htaccess
+++ b/docker/public/.htaccess
@@ -1,0 +1,14 @@
+# This .htaccess file should only be used inside the testing docker envs
+
+RewriteEngine on
+RewriteRule ^/?(?:ar|eu|bn|bg|ca|zh-CHS|zh-CHT|da|nl|en|fi|fr|gl|de|el|he|hu|id|it|ja|ko|lv|ms|my|ne|no|fa|pl|pt|ru|es|sw|sv|tl|th|hi|tr|uk|vi|km|ta|si|en-US|zh-Hant-HK)($|/.*$) $1 [L]
+
+RewriteCond %{REQUEST_URI} /custom_response*
+RewriteRule "custom_response/?.*" "custom_index.php"
+
+# Intercept only static content: html and htm urls
+# Warning: do not remove this line or other content could be loaded
+RewriteCond %{REQUEST_URI} /$ [OR]
+RewriteCond %{REQUEST_URI} \.(html|htm|shtml|php|php3|phtml)
+# Use the wovn_index.php to handle static pages
+RewriteRule .? wovn_index.php [L]

--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -1,0 +1,12 @@
+<?php
+//require_once('WOVN.php/src/wovn_interceptor.php');
+
+$content = file_get_contents('php://input');
+
+$response_json = json_decode($content, true);
+$response_options = $response_json['response'];
+foreach ($response_options['headers'] as $key => $value) {
+    header("{$key}: {$value}");
+}
+header("Content-Type: {$response_options['content_type']}");
+echo($response_options['body']);

--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -1,4 +1,6 @@
 <?php
+require_once('WOVN.php/src/wovn_interceptor.php');
+
 $content = file_get_contents('php://input');
 
 $response_json = json_decode($content, true);

--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -8,5 +8,5 @@ $response_options = $response_json['response'];
 foreach ($response_options['headers'] as $key => $value) {
     header("{$key}: {$value}");
 }
-header("content-type: {$response_options['content_type']}");
+header("Content-Type: {$response_options['content-type']}");
 echo($response_options['body']);

--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -1,6 +1,4 @@
 <?php
-//require_once('WOVN.php/src/wovn_interceptor.php');
-
 $content = file_get_contents('php://input');
 
 $response_json = json_decode($content, true);

--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -8,5 +8,5 @@ $response_options = $response_json['response'];
 foreach ($response_options['headers'] as $key => $value) {
     header("{$key}: {$value}");
 }
-header("Content-Type: {$response_options['content_type']}");
+header("content-type: {$response_options['content_type']}");
 echo($response_options['body']);

--- a/docker/public/wovn.ini
+++ b/docker/public/wovn.ini
@@ -1,0 +1,8 @@
+project_token = "TOKEN"
+url_pattern_name = "path"
+default_lang = "en"
+api_url = "localhost:3561"
+encoding = "UTF-8"
+supported_langs[] = "ja"
+supported_langs[] = "fr"
+logging[max_line_length] = 5124

--- a/docker/public/wovn.ini
+++ b/docker/public/wovn.ini
@@ -1,7 +1,6 @@
 project_token = "TOKEN"
 url_pattern_name = "path"
 default_lang = "en"
-api_url = "localhost:3561"
 encoding = "UTF-8"
 supported_langs[] = "ja"
 supported_langs[] = "fr"

--- a/docker/public/wovn_index.php
+++ b/docker/public/wovn_index.php
@@ -8,7 +8,7 @@ $parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 if ($parsed_url) {
     $paths = wovn_helper_detect_paths(dirname(__FILE__), $parsed_url);
 
-    if (strrpos($_SERVER["REQUEST_URI"], 'custom_response') != false) {
+    if (preg_match('/\/custom_response\//', $_SERVER["REQUEST_URI"]) == 1) {
         $included = wovn_helper_include_by_paths(array('custom_index.php'));
         error_log("[DEBUG] Is custom request.");
     } else {

--- a/docker/public/wovn_index.php
+++ b/docker/public/wovn_index.php
@@ -8,15 +8,10 @@ $parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 if ($parsed_url) {
     $paths = wovn_helper_detect_paths(dirname(__FILE__), $parsed_url);
 
-    if (preg_match('/\/custom_response\//', $_SERVER["REQUEST_URI"]) == 1) {
-        $included = wovn_helper_include_by_paths(array('custom_index.php'));
-        error_log("[DEBUG] Is custom request.");
-    } else {
-        # SSI USER: please swap comments on the two lines below
-        # (also see the SSI comment in the 404 section below)
-        $included = wovn_helper_include_by_paths($paths);
-        # $included = wovn_helper_include_by_paths_with_ssi($paths);
-    }
+    # SSI USER: please swap comments on the two lines below
+    # (also see the SSI comment in the 404 section below)
+    $included = wovn_helper_include_by_paths($paths);
+    # $included = wovn_helper_include_by_paths_with_ssi($paths);
 } else {
     $included = false;
 }

--- a/docker/public/wovn_index.php
+++ b/docker/public/wovn_index.php
@@ -1,0 +1,38 @@
+<?php
+# Enable WOVN.php library
+require_once("WOVN.php/src/wovn_interceptor.php");
+require_once("WOVN.php/src/wovn_helper.php");
+
+$parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+
+if ($parsed_url) {
+    $paths = wovn_helper_detect_paths(dirname(__FILE__), $parsed_url);
+
+    if (strrpos($_SERVER["REQUEST_URI"], 'custom_response') != false) {
+        $included = wovn_helper_include_by_paths(array('custom_index.php'));
+        error_log("[DEBUG] Is custom request.");
+    } else {
+        # SSI USER: please swap comments on the two lines below
+        # (also see the SSI comment in the 404 section below)
+        $included = wovn_helper_include_by_paths($paths);
+        # $included = wovn_helper_include_by_paths_with_ssi($paths);
+    }
+} else {
+    $included = false;
+}
+
+# Set 404 status code if file not included
+if (!$included) {
+    header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
+
+    # Look for 404.html file in the root directory
+    $paths_404 = array(dirname(__FILE__) . "/404.html");
+
+    # SSI USER: please swap comments on the two lines below as you did above
+    $included_404 = wovn_helper_include_by_paths($paths_404);
+    # $included_404 = wovn_helper_include_by_paths_with_ssi($paths_404);
+
+    if (!$included_404) {
+        echo "Page Not Found";
+    }
+}


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-901

### Comments
This PR is a quality of life PR that improves debugging using the docker environment.

Most notably, this PR adds the ability to send a request to any route prefixed by`/custom_response`, and dictate what the response should be.

You can decide:
- Response headers
- Response HTTP status code
- Response body

You need to include a JSON body with such requests:
```
{
    "response": {
        "body": "foo2",
        "content-type": "text/html",
        "status": 200,
        "headers": { "X-WovnTest": "Foo" }
    }
}
```
Theoretically speaking, content-type is also a header, but it is included in its separate field.

In addition to this universal route, access to normal paths (files) are also supported, as long as they do not contain `custom_response` in their name or path.

**Changes made:**
- No longer copies over configuration files (wovn.ini, .htaccess etc) from the sample files. These files are now directly defined in the web root folder
- a customized wovn_index.php is added to allow custom/universal routes
- a customized .htaccess is added to allow custom/universal routes
- a custom_index.php file is added to handle custom/universal routes

### Release comments (new feature)
