### PR TITLE
[SUP-1015] Change regular expression to support SSI

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get install -y --force-yes debian-keyring debian-archive-keyring
 RUN apt-get -y -f install git unzip
 RUN apt-get clean
 
-# enable mod_rewrite
-RUN a2enmod rewrite
+# enable mod_rewrite/mod_include(for SSI)
+RUN a2enmod rewrite include
 
 # install xdebug
 RUN pecl install xdebug-2.9.0

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.10.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.10.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/SSI.php
+++ b/src/wovnio/wovnphp/SSI.php
@@ -14,7 +14,7 @@ class SSI
 
     public static function readFileRecursive($includePath, $rootDir, &$limit)
     {
-        $ssiIncludeRegexp = '/<!--#include virtual="(.+?)"\s*-->/';
+        $ssiIncludeRegexp = '/<!--#include\s+virtual="(.+?)"\s*-->/';
         $includeDir = dirname($includePath);
         $code = self::getContents($includePath);
         $fixSSIPath = function ($path, $dir) {

--- a/test/integration/SSIWovnIndexSampleTest.php
+++ b/test/integration/SSIWovnIndexSampleTest.php
@@ -61,7 +61,6 @@ class SSIWovnIndexSampleTest extends TestCase
 
     public function testWithSSIWhichIncludeMultipleSpaces()
     {
-        // If you are getting errors here and you modified wovn_index_sample, check the 'sed' commands above
         $this->touch('ssi.html', '<?php echo \'ssi\'; ?> <!--#include  virtual="include.html" -->');
         $this->touch('include.html', 'include <!--#include  virtual="nested.html" -->');
         $this->touch('nested.html');

--- a/test/integration/SSIWovnIndexSampleTest.php
+++ b/test/integration/SSIWovnIndexSampleTest.php
@@ -59,6 +59,15 @@ class SSIWovnIndexSampleTest extends TestCase
         $this->assertEquals('ssi include This is nested.html', $this->runWovnIndex('/ssi.html'));
     }
 
+    public function testWithSSIWhichIncludeMultipleSpaces()
+    {
+        // If you are getting errors here and you modified wovn_index_sample, check the 'sed' commands above
+        $this->touch('ssi.html', '<?php echo \'ssi\'; ?> <!--#include  virtual="include.html" -->');
+        $this->touch('include.html', 'include <!--#include  virtual="nested.html" -->');
+        $this->touch('nested.html');
+        $this->assertEquals('ssi include This is nested.html', $this->runWovnIndex('/ssi.html'));
+    }
+
     private function runWovnIndex($request_uri)
     {
         $_SERVER['HTTP_HOST'] = 'localhost';


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/SUP-1015

### Comments
WOVN supports SSI(Server Side Include).
When SSI is found by regular expression, WOVN.php tries to load included file.
This issue is caused by not flexible regular expression, and it failed to found SSI.

This PR fix:
- Fix reguler expression
- Add mod_include of Apache for Dockerfile to use SSI

When you try this one, please be careful about the followings.
- rebuild docker image by `make build` to include mod_include
- configure SSI in wovn_index.php
- Add the following to .htaccess to enable SSI
```
Options +Includes
AddType text/html .html
AddOutputFilter INCLUDES .html
```

Then, you will be able to include files by `<!--#include  virtual="ssi.html" -->`.

### Release comments (new feature)
