### PR TITLE
tests: Implement status code for custom responses in test docker

### DIFF
--- a/docker/public/custom_index.php
+++ b/docker/public/custom_index.php
@@ -8,5 +8,7 @@ $response_options = $response_json['response'];
 foreach ($response_options['headers'] as $key => $value) {
     header("{$key}: {$value}");
 }
+$status = $response_options['status'];
+header("X-PHP-Response-Code: $status", true, $status);
 header("Content-Type: {$response_options['content-type']}");
 echo($response_options['body']);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

### Comments
To be the same as other backends for testing, you should be able to send 
```
{
    "response": {
        "body": "<html><body>foo</body></html>",
        "content-type": "text/html",
        "status": 201,
        "headers": { "X-WovnTest": "Foo" }
    }
}
```
and receive the expected status code.

PHP 5.3 makes it a little difficult to set the status code. Not that this docker supports 5.3 but I thought i'd make it compatible just in case.  I used the strategy in https://stackoverflow.com/a/12018482

### Release comments (new feature)
