### PR TITLE
[ST-1363] Change disable_api_request_for_default_lang default to true

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.13.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.13.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -82,7 +82,7 @@ class Store
             'custom_lang_aliases' => array(),
             'use_proxy' => false,
             'override_content_length' => false,
-            'disable_api_request_for_default_lang' => false,
+            'disable_api_request_for_default_lang' => true,
             'compress_api_requests' => true,
             'ignore_paths' => array(),
             'ignore_regex' => array(),

--- a/test/helpers/StoreAndHeadersFactory.php
+++ b/test/helpers/StoreAndHeadersFactory.php
@@ -35,7 +35,8 @@ class StoreAndHeadersFactory
             'url_pattern_name' => 'query',
             'lang_param_name' => 'wovn',
             'project_token' => '123456',
-            'translate_canonical_tag' => true
+            'translate_canonical_tag' => true,
+            'disable_api_request_for_default_lang' => false
         );
 
         return array_merge($defaultOptions, $options);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-1363

`disable_api_request_for_default_lang` was `false` by default.
- false: Do request to html-swapper for default lang
- true: Don'T request to html-swapper for default lang

It is expensive for WOVN.php to make an API request for default lang.
So, this PR make it `true` as default.

### Comments

### Release comments (new feature)
