### PR TITLE
[ST-1340] Show more detail of file_get_contents error

### DIFF
--- a/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
@@ -36,11 +36,10 @@ class FileGetContentsRequestHandler extends AbstractRequestHandler
         list($response, $response_headers) = $this->fileGetContents($url, $http_context);
 
         if ($response === false) {
-            preg_match('{HTTP\/\S*\s(\d{3})}', $response_headers[0], $match);
+            $error_type = error_get_last() ? error_get_last()['type'] : '';
+            $error_in_response = $response_headers[0];
 
-            $http_error_code = $match[1];
-
-            return array(null, $response_headers, "[fgc] Request failed ($http_error_code)");
+            return array(null, $response_headers, "[fgc] Request failed ($error_type - $error_in_response)");
         }
 
         foreach ($response_headers as $c => $h) {

--- a/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
@@ -4,6 +4,7 @@ namespace Wovnio\Utils\RequestHandlers;
 require_once 'AbstractRequestHandler.php';
 
 use Wovnio\Utils\RequestHandlers\AbstractRequestHandler;
+use Wovnio\Wovnphp\Logger;
 
 class FileGetContentsRequestHandler extends AbstractRequestHandler
 {
@@ -36,7 +37,12 @@ class FileGetContentsRequestHandler extends AbstractRequestHandler
         list($response, $response_headers) = $this->fileGetContents($url, $http_context);
 
         if ($response === false) {
-            $error_type = error_get_last() ? error_get_last()['type'] : '';
+            $error_type = '';
+            if ($last_error = error_get_last()) {
+                $error_type = $last_error['type'];
+                Logger::get()->error($last_error['message']);
+            }
+
             $error_in_response = $response_headers[0];
 
             return array(null, $response_headers, "[fgc] Request failed ($error_type - $error_in_response)");


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-1340

- Add more detail of error by using `error_get_last()` to `X-Wovn-Error` header.
  Header will have `([error-type] - [error-in-response-for-html-swapper])`.
  e.g. `X-Wovn-Error: [fgc] Request failed (2 - HTTP\\/1.1 500 Internal Server Error)`
  - error-type: error type code (https://www.php.net/manual/en/errorfunc.constants.php)
  - error-in-response-for-html-swapper: error message in `$http_response_header[0]` (https://www.php.net/manual/en/reserved.variables.httpresponseheader.php)
- Log error message in `error_get_last()`.

### Comments

### Release comments (new feature)
