### PR TITLE
Executes memory free only for PHP5.

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.13.2';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.13.3';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -77,6 +77,10 @@ class HtmlConverter
         }
         $converted_html = $html;
 
+        if (strpos($converted_html, 'wovn-ignore') === false) {
+            return $converted_html;
+        }
+
         $dom = SimpleHtmlDom::str_get_html($converted_html, $encoding, false, false, $encoding, false);
         if ($dom) {
             $this->replaceDom($dom, $this->marker);

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -77,10 +77,6 @@ class HtmlConverter
         }
         $converted_html = $html;
 
-        if (strpos($converted_html, 'wovn-ignore') === false) {
-            return $converted_html;
-        }
-
         $dom = SimpleHtmlDom::str_get_html($converted_html, $encoding, false, false, $encoding, false);
         if ($dom) {
             $this->replaceDom($dom, $this->marker);

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -47,6 +47,12 @@ class SimpleHtmlDomNode {
     // clean up memory due to php5 circular references memory leak...
     function clear()
     {
+        if (defined('PHP_VERSION_ID')) {
+            if (PHP_VERSION_ID > 60000) {
+                return;
+            }
+        }
+
         $this->dom = null;
         $this->parent = null;
         $this->node_begin = null;


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
The SimpleHtmlDOM fork we use suffers from segfaults if the number of nodes in the DOM is high. The segfaults are caused by the `$var -> null;` assignments. Since those are only need for PHP5, a version check is implemented so that this does not affect users of other versions of PHP.

### Comments

### Release comments (new feature)
