### PR TITLE
[SUP-1505] Fix redirect loop with custom domain + source pattern.

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.2';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -286,7 +286,7 @@ class Headers
         // Two languages can be using different files on the customer side, and they may use redirects.
         // e.g. customer redirect's /french/page.php -> /global/page.php. WOVN modifies it back to /french/page.php
         // For other URL patterns, we translate the redirect to keep the same lang code but in this case it creates a loop
-        if ($newLocation && !Url::isSameHostAndPath($originalUrl, $newLocation)) {
+        if ($newLocation && !Url::isSameHostAndPath($this->originalUrl, $newLocation, $this)) {
             header($locationHeader . ': ' . $newLocation);
         }
     }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -10,6 +10,7 @@ class Headers
     public $protocol;
     public $originalHost;
     public $originalPath;
+    public $originalUrl;
     public $host;
     public $pathname;
     public $url;
@@ -64,6 +65,9 @@ class Headers
         $exploded = explode('?', $clientRequestUri);
         $this->pathname = $exploded[0];
         $this->originalPath = $this->pathname;
+
+        $this->originalUrl = $this->protocol . '://' . $this->originalHost . $this->originalPath;
+
         if ($store->settings['url_pattern_name'] === 'path' || $store->settings['url_pattern_name'] === 'custom_domain') {
             $this->pathname = $this->removeLang($exploded[0]);
         }
@@ -132,6 +136,7 @@ class Headers
             } else {
                 $rp = '/' . $this->store->settings['url_pattern_reg'] . '/';
                 preg_match($rp, $full_url, $match);
+
                 if (isset($match['lang'])) {
                     $lang_identifier = $match['lang'];
                     $lang_code = Lang::formatLangCode($lang_identifier, $this->store);
@@ -277,7 +282,11 @@ class Headers
             $newLocation = Url::addLangCode($redirectLocation, $this->store, $urlLanguage, $this);
         }
 
-        if ($newLocation) {
+        // When using custom domain + source pattern, it is possible for the customer to redirect to a different language source file.
+        // Two languages can be using different files on the customer side, and they may use redirects.
+        // e.g. customer redirect's /french/page.php -> /global/page.php. WOVN modifies it back to /french/page.php
+        // For other URL patterns, we translate the redirect to keep the same lang code but in this case it creates a loop
+        if ($newLocation && !Url::isSameHostAndPath($originalUrl, $newLocation)) {
             header($locationHeader . ': ' . $newLocation);
         }
     }

--- a/src/wovnio/wovnphp/Url.php
+++ b/src/wovnio/wovnphp/Url.php
@@ -301,7 +301,7 @@ class Url
 
     // parameters are not assumed to be absolute URLs
     // Fills missing components using request headers
-    public static function isSameHostAndPath($a, $b, $headers) 
+    public static function isSameHostAndPath($a, $b, $headers)
     {
         // This doesn't have to be a perfect conversion of a URL,
         // we just need to make them parsable so we can compare

--- a/src/wovnio/wovnphp/Url.php
+++ b/src/wovnio/wovnphp/Url.php
@@ -299,6 +299,28 @@ class Url
         return preg_match('/^\//', $uri);
     }
 
+    // parameters are not assumed to be absolute URLs
+    // Fills missing components using request headers
+    public static function isSamePathAndHost($a, $b, $headers) {
+        if (!isAbsoluteUri($a)) {
+            $a = $headers->protocol . '://' . $headers->originalHost . $a;
+        }
+
+        if (!isAbsoluteUri($b)) {
+            $b = $headers->protocol . '://' . $headers->originalHost . $b;
+        }
+
+        $parsed_url_a = parse_url($a);
+        $parsed_url_b = parse_url($b);
+
+        if ($parsed_url_a && $parsed_url_b) {
+            return $parsed_url_a['host'] == $parsed_url_b['host']
+                && $parsed_url_a['path'] == $parsed_url_b['path'];
+        }
+
+        return false;
+    }
+
     private static function makeSegmentsFromAbsoluteUrl($absoluteUrl)
     {
         preg_match(

--- a/src/wovnio/wovnphp/Url.php
+++ b/src/wovnio/wovnphp/Url.php
@@ -301,12 +301,15 @@ class Url
 
     // parameters are not assumed to be absolute URLs
     // Fills missing components using request headers
-    public static function isSamePathAndHost($a, $b, $headers) {
-        if (!isAbsoluteUri($a)) {
+    public static function isSameHostAndPath($a, $b, $headers) 
+    {
+        // This doesn't have to be a perfect conversion of a URL,
+        // we just need to make them parsable so we can compare
+        if (!Url::isAbsoluteUri($a)) {
             $a = $headers->protocol . '://' . $headers->originalHost . $a;
         }
 
-        if (!isAbsoluteUri($b)) {
+        if (!Url::isAbsoluteUri($b)) {
             $b = $headers->protocol . '://' . $headers->originalHost . $b;
         }
 
@@ -314,8 +317,11 @@ class Url
         $parsed_url_b = parse_url($b);
 
         if ($parsed_url_a && $parsed_url_b) {
+            $path_a = isset($parsed_url_a['path']) ? $parsed_url_a['path'] : '';
+            $path_b = isset($parsed_url_b['path']) ? $parsed_url_b['path'] : '';
+
             return $parsed_url_a['host'] == $parsed_url_b['host']
-                && $parsed_url_a['path'] == $parsed_url_b['path'];
+                && $path_a == $path_b;
         }
 
         return false;

--- a/test/helpers/EnvFactory.php
+++ b/test/helpers/EnvFactory.php
@@ -12,6 +12,11 @@ class EnvFactory
             'HTTP_SCHEME' => $parsed_url['scheme'],
             'HTTP_HOST' => $parsed_url['host'],
         );
+
+        if ($parsed_url['scheme'] === 'https') {
+            $env['HTTPS'] = 'on';
+        }
+
         if (array_key_exists('query', $parsed_url)) {
             $env['QUERY_STRING'] = $parsed_url['query'];
             $path_and_query .= '?' . $parsed_url['query'];

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -1298,7 +1298,7 @@ class HeadersTest extends TestCase
         );
 
         // TODO: This behavior probably isn't correct but this is the current behavior
-        // We assume the Location header never contains any wovn lang codes, so for path, query we will add double lang codes
+        // We assume the Location header never contains any wovn lang codes, so for path we will add double lang codes
         $pathSettings = array(
             'url_pattern_name' => 'path'
         );
@@ -1400,7 +1400,7 @@ class HeadersTest extends TestCase
         );
 
         // TODO: This behavior probably isn't correct but this is the current behavior
-        // We assume the Location header never contains any wovn lang codes, so for path, query we will add double lang codes
+        // We assume the Location header never contains any wovn lang codes, so for path we will add double lang codes
         $pathSettings = array(
             'url_pattern_name' => 'path'
         );

--- a/test/unit/UrlTest.php
+++ b/test/unit/UrlTest.php
@@ -8,6 +8,7 @@ require_once 'src/wovnio/wovnphp/Store.php';
 require_once 'src/wovnio/wovnphp/Headers.php';
 require_once 'src/wovnio/wovnphp/Lang.php';
 
+use Wovnio\Test\Helpers\EnvFactory;
 use Wovnio\test\Helpers\StoreAndHeadersFactory;
 use Wovnio\Test\Helpers\TestUtils;
 
@@ -1409,5 +1410,26 @@ class UrlTest extends TestCase
             list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $additional_env);
             $this->assertEquals($expected, Url::shouldIgnoreBySitePrefixPath($uri, $store->settings));
         }
+    }
+
+    public function testIsSameHostAndPath()
+    {
+        $requestUrl = "https://site.com/page.php";
+        $env = EnvFactory::makeEnvFromUrl($requestUrl);
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', array(), $env);
+
+        $this->assertEquals(false, Url::isSameHostAndPath("/a", "/b", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("/path", "/path", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("/path?a=b", "/path?a=b", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("/path?a=b", "/path?c=d", $headers));
+
+        $this->assertEquals(true, Url::isSameHostAndPath("relative_path", "relative_path", $headers));
+
+        $this->assertEquals(true, Url::isSameHostAndPath("https://site.com", "https://site.com", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("https://site.com/", "https://site.com/", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("https://site.com/path", "https://site.com/path", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("https://site.com/path?a=b", "https://site.com/path?a=b", $headers));
+        $this->assertEquals(true, Url::isSameHostAndPath("https://site.com/path?a=b", "https://site.com/path?c=d", $headers));
+        $this->assertEquals(false, Url::isSameHostAndPath("https://site.com/path", "https://site.com/path2", $headers));
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/SUP-1505?focusedCommentId=49454
### Comments
This can happen with custom domain + source pattern
```
custom_domain_langs: {
   en: { url: "site.com/global/" },
   fr: { url: "site.com/french/", source: "site.com/french/ },
}
```
`site.com/french/page.php` is a different file from `site.com/global/page.php` on disk, and the customer may send a redirect between them.

```
1. Request: https://site.com/french/page.php Lang code: fr
2. Customer redirect: https://site.com/global/page.php
3. WOVN tries to convert redirect to "fr" to maintain language: https://site.com/french/page.php
Redirect loop.
```

I want to try and prevent this by checking after step 3, did we convert the redirect to the same URL as the original request? If so, don't change the location.


### Release comments (new feature)
