### PR TITLE
[ST-1405] initialize http_response_header with empty array before returning

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
@@ -59,6 +59,7 @@ class FileGetContentsRequestHandler extends AbstractRequestHandler
 
     public function fileGetContents($url, $http_context)
     {
+        $http_response_header = [];
         $response = @file_get_contents($url, false, $http_context);
         return array($response, $http_response_header);
     }

--- a/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/FileGetContentsRequestHandler.php
@@ -59,7 +59,7 @@ class FileGetContentsRequestHandler extends AbstractRequestHandler
 
     public function fileGetContents($url, $http_context)
     {
-        $http_response_header = [];
+        $http_response_header = array();
         $response = @file_get_contents($url, false, $http_context);
         return array($response, $http_response_header);
     }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

https://wovnio.atlassian.net/browse/ST-1405
In certain installations of PHP, the normally predefined variable `http_response_header` is left undefined. This change initializes it as an empty array first.

### Comments

### Release comments (new feature)
