### PR TITLE
fix: [SUP-1480] Improve content-type detection

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.2';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.3';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Utils.php
+++ b/src/wovnio/wovnphp/Utils.php
@@ -51,9 +51,9 @@ class Utils
                 return true;
             } elseif (preg_match('/text/', strtolower($contentType))) {
                 return $buffer != strip_tags($buffer);
-            } else {
-                return false;
             }
+            // finfo can still return octet-stream even if it is really HTML but contains certain characters
+            // So we should still fallback to a buffer check
         }
         return $buffer != strip_tags($buffer);
     }

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -97,6 +97,7 @@ class UtilsTest extends TestCase
         $this->assertEquals(false, Utils::isHtml('this is not html, even tho it contains < and >'));
 
         $this->assertEquals(true, Utils::isHtml('<html><head></head><body><p>this is html</p></body></html>'));
+        $this->assertEquals(true, Utils::isHtml("<!DOCTYPE html><html lang=\"ja\"><head></head><body>contains unicode \0020</body></html>"));
         $this->assertEquals(true, Utils::isHtml('<?php require_once(\'{$this->docRoot}/WOVN.php/src/wovn_interceptor.php\'); ?><html><head></head><body>test</body></html>'));
         $this->assertEquals(false, Utils::isHtml('this is json'));
     }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/SUP-1480
### Comments
`finfo` can't be trusted completely. If it doesn't return `text/html` e.g. `application/octet-stream`, it may still be HTML. Certain characters cause it to fail.
### Release comments (new feature)
