### PR TITLE
fix: [ST-1732] Change replace marker for title tag

### DIFF
--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -36,7 +36,10 @@ make clean
 
 ### Debug by XDebug
 #### XDebug configuration for VSCode
-You can use the following setting for `launch.json`.  
+Install `PHP Debug` extension from your Extensions menu in VSCode.  
+Make it possible to load `zend_extension` in `docker/php.ini`.  
+
+You can use the following setting for `.vscode/launch.json`.  
 After start debugging, you can break by break points.  
 ```
 {
@@ -65,7 +68,7 @@ After start debugging, you can break by break points.
 ```
 
 #### Debug by XDebug
-Start `Listen for XDebug` from `Run` menu in VSCode.  
+Start `Listen for XDebug` from `Run and Debug` menu in VSCode.  
 You can set break point.  
 
 If you have a trouble, Check `zend_extension` in `docker/php.ini`.  

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.4';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.14.5';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -357,7 +357,11 @@ class HtmlConverter
             return;
         }
 
-        $key = $marker->addCommentValue($originalText);
+        if ($element->tag == 'title') {
+            $key = $marker->addValue($originalText);
+        } else {
+            $key = $marker->addCommentValue($originalText);
+        }
         $element->innertext = $key;
     }
 

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -849,6 +849,15 @@ class HtmlConverterTest extends TestCase
                 '</body></html>',
             ),
             array(
+                'with ignored title',
+
+                '<html><head><title wovn-ignore>hello</title></head><body><a>hello</a></body></html>',
+
+                '<html><head><title wovn-ignore>__wovn-backend-ignored-key-0</title></head><body><a>hello</a></body></html>',
+
+                '<html><head><title wovn-ignore>hello</title></head><body><a>hello</a></body></html>',
+            ),
+            array(
                 'with script',
 
                 '<html><head>'.
@@ -972,14 +981,15 @@ class HtmlConverterTest extends TestCase
 
     public function testConvertToAppropriateBodyForApiWithMultipleWovnIgnore()
     {
-        $html = '<html><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
+        $html = '<html><head><title wovn-ignore>hello</title></head><body><a wovn-ignore>hello</a>ignore<div wovn-ignore>world</div></body></html>';
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
         $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
         list($translated_html, $marker) = $this->executeConvert($converter, $html, 'UTF-8', '_removeWovnIgnore');
         $keys = $marker->keys();
 
-        $this->assertEquals(2, count($keys));
-        $this->assertEquals("<html><body><a wovn-ignore>$keys[0]</a>ignore<div wovn-ignore>$keys[1]</div></body></html>", $translated_html);
+        $this->assertEquals(3, count($keys));
+        $this->assertEquals('__wovn-backend-ignored-key-0', $keys[0]);
+        $this->assertEquals("<html><head><title wovn-ignore>$keys[0]</title></head><body><a wovn-ignore>$keys[1]</a>ignore<div wovn-ignore>$keys[2]</div></body></html>", $translated_html);
     }
 
     public function testConvertToAppropriateBodyForApiWithForm()


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-1732

The flow of issue is:
1. Customer set `wovn-ignore` attribute for `title` tag. e.g. `<title wovn-ignore>こんにちは</title>`
2. WOVN.php add replace marker for ignored element. e.g. `<title wovn-ignore><!-- __wovn-backend-ignored-key-0 --></title>`
3. html-swapper escapes. e.g. `<title wovn-ignore="">&lt;!-- __wovn-backend-ignored-key-0 --&gt;</title>` 
4. WOVN.php tris to revert it with original value, but `<!-- __wovn-backend-ignored-key-0 -->` doesn't match with `&lt;!-- __wovn-backend-ignored-key-0 --&gt;` and it would remain as marker.

Escape in html-swapper is not wrong, because title tag is just text, so title tag should not include comment node.
https://html.spec.whatwg.org/multipage/semantics.html#the-title-element

This PR changes marker for title tag to not have character which is escaped by html-swapper.
With this PR, HTML after processed replace marker would be like `<title wovn-ignore>__wovn-backend-ignored-key-0</title>`.

### Comments

### Release comments (new feature)
