### PR TITLE
fix: [ST-1828] wovn_helper now includes files in the global scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ test/integration/test/integration/wovn_index_sample_workspace
 !/docker/public/wovn.json
 !/docker/public/testdir/*
 !/docker/public/testpage.html
+!/docker/public/ssi_*.html
 !/docker/public/testpage-redirect-origin.php
 !/docker/public/index.html
 !/docker/apache.yml

--- a/docker/public/ssi_included.html
+++ b/docker/public/ssi_included.html
@@ -1,0 +1,1 @@
+<div>Included content</div>

--- a/docker/public/ssi_page.html
+++ b/docker/public/ssi_page.html
@@ -4,7 +4,7 @@
         <title>test</title>
     </head>
     <body>
-        <!--#include virtual="/included.html" -->
+        <!--#include virtual="/ssi_included.html" -->
         <h1>This is a test page using SSI</h1>
     </body>
 </html>

--- a/docker/public/ssi_page.html
+++ b/docker/public/ssi_page.html
@@ -1,0 +1,10 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>test</title>
+    </head>
+    <body>
+        <!--#include virtual="/included.html" -->
+        <h1>This is a test page using SSI</h1>
+    </body>
+</html>

--- a/docker/public/wovn_index.php
+++ b/docker/public/wovn_index.php
@@ -3,31 +3,47 @@
 require_once("WOVN.php/src/wovn_interceptor.php");
 require_once("WOVN.php/src/wovn_helper.php");
 
-$parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+# SSI USERS: set to true to translate SSI content
+$wovn_use_ssi = false;
 
-if ($parsed_url) {
-    $paths = wovn_helper_detect_paths(dirname(__FILE__), $parsed_url);
+$wovn_included = false;
+$wovn_parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 
-    # SSI USER: please swap comments on the two lines below
-    # (also see the SSI comment in the 404 section below)
-    $included = wovn_helper_include_by_paths($paths);
-    # $included = wovn_helper_include_by_paths_with_ssi($paths);
-} else {
-    $included = false;
+if ($wovn_parsed_url) {
+    $wovn_paths = wovn_helper_detect_paths(dirname(__FILE__), $wovn_parsed_url);
+
+    if ($wovn_use_ssi) {
+        $wovn_included = wovn_helper_include_by_paths_with_ssi($wovn_paths);
+    } else {
+        $wovn_file_to_include = wovn_helper_get_first_file_path($wovn_paths);
+        if ($wovn_file_to_include) {
+            chdir(dirname($wovn_file_to_include));
+            include($wovn_file_to_include);
+            $wovn_included = true;
+        }
+    }
 }
 
 # Set 404 status code if file not included
-if (!$included) {
+if (!$wovn_included) {
     header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
 
     # Look for 404.html file in the root directory
-    $paths_404 = array(dirname(__FILE__) . "/404.html");
+    $wovn_paths_404 = array(dirname(__FILE__) . "/404.html");
 
-    # SSI USER: please swap comments on the two lines below as you did above
-    $included_404 = wovn_helper_include_by_paths($paths_404);
-    # $included_404 = wovn_helper_include_by_paths_with_ssi($paths_404);
+    $wovn_included_404 = false;
+    if ($wovn_use_ssi) {
+        $wovn_included_404 = wovn_helper_include_by_paths_with_ssi($wovn_paths_404);
+    } else {
+        $wovn_file_to_include = wovn_helper_get_first_file_path($wovn_paths_404);
+        if ($wovn_file_to_include) {
+            chdir(dirname($wovn_file_to_include));
+            include($wovn_file_to_include);
+            $wovn_included_404 = true;
+        }
+    }
 
-    if (!$included_404) {
+    if (!$wovn_included_404) {
         echo "Page Not Found";
     }
 }

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.16.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.17.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovn_helper.php
+++ b/src/wovn_helper.php
@@ -7,7 +7,7 @@ use Wovnio\Wovnphp\SSI;
 // static websites using WOVN.php.
 // phpcs:disable Squiz.NamingConventions.ValidFunctionName.NotCamelCaps
 
-function reduce_slashes($path)
+function wovn_reduce_slashes($path)
 {
     # Reduces a sequence of slashes to a single slash
     # e.g. '///./////.///' -> '/././'
@@ -22,12 +22,12 @@ function reduce_slashes($path)
     return $path;
 }
 
-function remove_dots_from_path($path)
+function wovn_remove_dots_from_path($path)
 {
     # Removes '/./ in paths and resolves '/../' in paths
     # From https://tomnomnom.com/posts/realish-paths-without-realpath
     # See also http://php.net/manual/en/function.realpath.php#84012
-    $path = reduce_slashes($path);
+    $path = wovn_reduce_slashes($path);
 
     $path_parts = explode('/', $path);
     $tmp_out = array();
@@ -60,9 +60,9 @@ function wovn_helper_default_index_files()
 
 function wovn_helper_detect_paths($local_dir, $path_of_url)
 {
-    $base_dir = realpath(remove_dots_from_path($local_dir));
+    $base_dir = realpath(wovn_remove_dots_from_path($local_dir));
     $request_path = $base_dir . '/' . $path_of_url;
-    $local_path = realpath(remove_dots_from_path($request_path));
+    $local_path = realpath(wovn_remove_dots_from_path($request_path));
     $inside_base_dir = $local_path && strpos($local_path, $base_dir) === 0;
     $local_path = $inside_base_dir ? $local_path : false;
 
@@ -80,16 +80,13 @@ function wovn_helper_detect_paths($local_dir, $path_of_url)
     }
 }
 
-function wovn_helper_include_by_paths($paths)
+function wovn_helper_get_first_file_path($paths)
 {
     foreach ($paths as $path) {
         if (is_file($path)) {
-            chdir(dirname($path));
-            include($path);
-            return true;
+            return $path;
         }
     }
-    return false;
 }
 
 function wovn_helper_include_by_paths_with_ssi($paths)

--- a/src/wovnio/wovnphp/SSI.php
+++ b/src/wovnio/wovnphp/SSI.php
@@ -5,7 +5,7 @@ require_once(__DIR__ . '/../../wovn_helper.php');
 
 // https://httpd.apache.org/docs/2.4/howto/ssi.html
 // Server-side Include (SSI) is an Apache feature that allows adding limited dynamic content to HTML pages.
-// For example, 
+// For example,
 //   - including other files <!--#include virtual="/footer.html" -->
 //   - adding the current date <!--#echo var="DATE_LOCAL" -->
 // Normally, this is done by Apache itself. But because we want to translate this extra content, we need to

--- a/src/wovnio/wovnphp/SSI.php
+++ b/src/wovnio/wovnphp/SSI.php
@@ -3,6 +3,14 @@ namespace Wovnio\Wovnphp;
 
 require_once(__DIR__ . '/../../wovn_helper.php');
 
+// https://httpd.apache.org/docs/2.4/howto/ssi.html
+// Server-side Include (SSI) is an Apache feature that allows adding limited dynamic content to HTML pages.
+// For example, 
+//   - including other files <!--#include virtual="/footer.html" -->
+//   - adding the current date <!--#echo var="DATE_LOCAL" -->
+// Normally, this is done by Apache itself. But because we want to translate this extra content, we need to
+// "manually" perform the SSI ourselves e.g. fetching the included files HTML and concatting it.
+// Note that we have only implemented the "include" part of SSI. There are other functions of SSI like date insertion that we have not implemented.
 class SSI
 {
     public static function readFile($includePath, $rootDir = null)

--- a/test/integration/SSIWovnIndexSampleTest.php
+++ b/test/integration/SSIWovnIndexSampleTest.php
@@ -31,9 +31,9 @@ class SSIWovnIndexSampleTest extends TestCase
         copy('../../../src/wovnio/wovnphp/SSI.php', 'WOVN.php/src/wovnio/wovnphp/SSI.php');
 
         exec('cp -r ../../../src WOVN.php/src');
-        exec('sed -e s/^\ \ \ \ ' . $inclusionCode .'$/\ \ \ \ #\ ' . $inclusionCode . '/ ' . $sampleIndexFile . ' > ' . $indexFile . '.tmp');
-        exec('sed -e s/^\ \ \ \ #\ ' . $ssiInclusionCode . '$/\ \ \ \ ' . $ssiInclusionCode . '/ ' . $indexFile . '.tmp' . ' > ' . $indexFile);
-        unlink($indexFile . '.tmp');
+
+        // Turn on SSI
+        exec('sed -e s/$wovn_use_ssi = false;/$wovn_use_ssi = true;/ ' . $sampleIndexFile . ' > ' . $indexFile);
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
     }

--- a/test/integration/SSIWovnIndexSampleTest.php
+++ b/test/integration/SSIWovnIndexSampleTest.php
@@ -33,7 +33,7 @@ class SSIWovnIndexSampleTest extends TestCase
         exec('cp -r ../../../src WOVN.php/src');
 
         // Turn on SSI
-        exec('sed -e s/$wovn_use_ssi = false;/$wovn_use_ssi = true;/ ' . $sampleIndexFile . ' > ' . $indexFile);
+        exec("sed -e 's/wovn_use_ssi = false;/wovn_use_ssi = true;/' $sampleIndexFile > $indexFile");
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
     }

--- a/wovn_index_sample.php
+++ b/wovn_index_sample.php
@@ -32,12 +32,8 @@ if (!$wovn_included) {
     $wovn_paths_404 = array(dirname(__FILE__) . "/404.html");
 
     $wovn_included_404 = false;
-
     if ($wovn_use_ssi) {
         $wovn_included_404 = wovn_helper_include_by_paths_with_ssi($wovn_paths_404);
-        if (!$wovn_included_404) {
-            echo "Page Not Found";
-        }
     } else {
         $wovn_file_to_include = wovn_helper_get_first_file_path($wovn_paths_404);
         if ($wovn_file_to_include) {
@@ -45,5 +41,9 @@ if (!$wovn_included) {
             include($wovn_file_to_include);
             $wovn_included_404 = true;
         }
+    }
+
+    if (!$wovn_included_404) {
+        echo "Page Not Found";
     }
 }

--- a/wovn_index_sample.php
+++ b/wovn_index_sample.php
@@ -3,31 +3,47 @@
 require_once("WOVN.php/src/wovn_interceptor.php");
 require_once("WOVN.php/src/wovn_helper.php");
 
-$parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+# SSI USERS: set to true to translate SSI content
+$wovn_use_ssi = false;
 
-if ($parsed_url) {
-    $paths = wovn_helper_detect_paths(dirname(__FILE__), $parsed_url);
+$wovn_included = false;
+$wovn_parsed_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 
-    # SSI USER: please swap comments on the two lines below
-    # (also see the SSI comment in the 404 section below)
-    $included = wovn_helper_include_by_paths($paths);
-    # $included = wovn_helper_include_by_paths_with_ssi($paths);
-} else {
-    $included = false;
+if ($wovn_parsed_url) {
+    $wovn_paths = wovn_helper_detect_paths(dirname(__FILE__), $wovn_parsed_url);
+
+    if ($wovn_use_ssi) {
+        $wovn_included = wovn_helper_include_by_paths_with_ssi($wovn_paths);
+    } else {
+        $wovn_file_to_include = wovn_helper_get_first_file_path($wovn_paths);
+        if ($wovn_file_to_include) {
+            chdir(dirname($wovn_file_to_include));
+            include($wovn_file_to_include);
+            $wovn_included = true;
+        }
+    }
 }
 
 # Set 404 status code if file not included
-if (!$included) {
+if (!$wovn_included) {
     header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
 
     # Look for 404.html file in the root directory
-    $paths_404 = array(dirname(__FILE__) . "/404.html");
+    $wovn_paths_404 = array(dirname(__FILE__) . "/404.html");
 
-    # SSI USER: please swap comments on the two lines below as you did above
-    $included_404 = wovn_helper_include_by_paths($paths_404);
-    # $included_404 = wovn_helper_include_by_paths_with_ssi($paths_404);
+    $wovn_included_404 = false;
 
-    if (!$included_404) {
-        echo "Page Not Found";
+    if ($wovn_use_ssi) {
+        $wovn_included_404 = wovn_helper_include_by_paths_with_ssi($wovn_paths_404);
+        if (!$wovn_included_404) {
+            echo "Page Not Found";
+        }
+    } else {
+        $wovn_file_to_include = wovn_helper_get_first_file_path($wovn_paths_404);
+        if ($wovn_file_to_include) {
+            chdir(dirname($wovn_file_to_include));
+            include($wovn_file_to_include);
+            $wovn_included_404 = true;
+        }
     }
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-1828
### Comments

Doing `include` inside of a function means the included files inherits the scope of the function. Customers may be declaring global variables inside of the included php file, but when included by `wovn_helper`, they become variables of our function scope, not global scope.

I changed the code to `include` at the top level. This means we have to be careful about variable naming since everything is in the global scope. I renamed all variables and functions to have a `wovn` prefix.

Refactor: I re-arranged the SSI code to be based on a `$wovn_use_ssi` variable rather than have commented out code that the user must uncomment. Because of the changes to fix this bug, it becomes confusing to explain which lines need to be commented out for SSI. It is simpler to have a boolean variable they can turn on.


### Release comments (new feature)
