### PR TITLE
feature: [ST-1887] Add no_hreflang_langs setting

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -332,8 +332,8 @@ and should be used for performance optimization.
 | [ignore_paths](#ignore_paths)                                                 | all                       | Setting paths that should be excluded from translation                      |
 | [ignore_regex](#ignore_regex)                                                 | all                       | Setting regex expressions on paths that should be excluded from translation |
 | [ignore_class](#ignore_class)                                                 | all                       | Setting the HTML classes that should be excluded from translation           |
-| [no_index_langs](#no_index_langs)                                             | all                       | Prevents search indexing, specified languages will not be included in SEO optimization tags |
-| [no_hreflang_langs](#no_hreflang_langs)                                       | all                       | Specified languages will not be included in SEO optimization tags           |
+| [no_index_langs](#no_index_langs)                                             | all                       | Prevents search indexing, specified languages will not be embedded in SEO optimization tags |
+| [no_hreflang_langs](#no_hreflang_langs)                                       | all                       | Specified languages will not be embedded in SEO optimization tags           |
 | [encoding](#encoding)                                                         | all                       | Setting HTML content encoding                                               |
 | [api_timeout](#api_timeout)                                                   | all                       | Setting timeout for translation requests                                    |
 | [api_timeout_search_engine_bots](#api_timeout_search_engine_bots)             | all                       | Setting timeout for translation requests for search engine bots             |

--- a/README.en.md
+++ b/README.en.md
@@ -332,8 +332,8 @@ and should be used for performance optimization.
 | [ignore_paths](#ignore_paths)                                                 | all                       | Setting paths that should be excluded from translation                      |
 | [ignore_regex](#ignore_regex)                                                 | all                       | Setting regex expressions on paths that should be excluded from translation |
 | [ignore_class](#ignore_class)                                                 | all                       | Setting the HTML classes that should be excluded from translation           |
-| [no_index_langs](#no_index_langs)                                             | all                       | Setting languages that should not be included in SEO optimization tags      |
-| [no_hreflang_langs](#no_hreflang_langs)                                       | all                       | Setting languages that should not be included in SEO optimization tags      |
+| [no_index_langs](#no_index_langs)                                             | all                       | Prevents search indexing, specified languages will not be included in SEO optimization tags |
+| [no_hreflang_langs](#no_hreflang_langs)                                       | all                       | Specified languages will not be included in SEO optimization tags           |
 | [encoding](#encoding)                                                         | all                       | Setting HTML content encoding                                               |
 | [api_timeout](#api_timeout)                                                   | all                       | Setting timeout for translation requests                                    |
 | [api_timeout_search_engine_bots](#api_timeout_search_engine_bots)             | all                       | Setting timeout for translation requests for search engine bots             |
@@ -496,28 +496,6 @@ ignore_class[] = no-translate
 }
 ```
 
-#### `no_index_langs`
-
-This parameter tells WOVN.php which languages's HTML should be set `noindex`
-to avoid index by web crawler. It also prevents `hreflang` tags from being emitted (see [no_hreflang_langs](#no_hreflang_langs)).
-
-For instance, if you want to avoid index for English pages, add `en` as below.
-`<meta name="robots" content="noindex">` tag will be inserted inside `head` tag
-for English pages.
-
-`wovn.ini`
-
-```ini
-no_index_langs[] = en
-```
-
-`wovn.json`
-
-```json
-{
-  "no_index_langs": ["en"]
-}
-```
 
 #### `no_hreflang_langs`
 
@@ -538,6 +516,29 @@ no_hreflang_langs[] = en
 ```json
 {
   "no_hreflang_langs": ["en"]
+}
+```
+
+#### `no_index_langs`
+
+This parameter tells WOVN.php which languages's HTML should be set `noindex`
+to avoid index by web crawler. It also prevents `hreflang` tags from being emitted (see [no_hreflang_langs](#no_hreflang_langs)).
+
+For instance, if you want to avoid index for English pages, add `en` as below.
+`<meta name="robots" content="noindex">` tag will be inserted inside `head` tag
+for English pages.
+
+`wovn.ini`
+
+```ini
+no_index_langs[] = en
+```
+
+`wovn.json`
+
+```json
+{
+  "no_index_langs": ["en"]
 }
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -288,7 +288,7 @@ NOT SUPPORTED
 #### `custom_domain_langs`
 
 This parameter is valid and required, when `url_pattern_name` is `custom_domain`.
-Set `custom_domain_langs` for all languagesed declared in `supported_langs` and original language.
+Set `custom_domain_langs` for all languages declared in `supported_langs`.
 
 `wovn.ini`
 
@@ -333,6 +333,7 @@ and should be used for performance optimization.
 | [ignore_regex](#ignore_regex)                                                 | all                       | Setting regex expressions on paths that should be excluded from translation |
 | [ignore_class](#ignore_class)                                                 | all                       | Setting the HTML classes that should be excluded from translation           |
 | [no_index_langs](#no_index_langs)                                             | all                       | Setting languages that should not be included in SEO optimization tags      |
+| [no_hreflang_langs](#no_hreflang_langs)                                       | all                       | Setting languages that should not be included in SEO optimization tags      |
 | [encoding](#encoding)                                                         | all                       | Setting HTML content encoding                                               |
 | [api_timeout](#api_timeout)                                                   | all                       | Setting timeout for translation requests                                    |
 | [api_timeout_search_engine_bots](#api_timeout_search_engine_bots)             | all                       | Setting timeout for translation requests for search engine bots             |
@@ -498,7 +499,7 @@ ignore_class[] = no-translate
 #### `no_index_langs`
 
 This parameter tells WOVN.php which languages's HTML should be set `noindex`
-to avoid index by web crawler.
+to avoid index by web crawler. It also prevents `hreflang` tags from being emitted (see [no_hreflang_langs](#no_hreflang_langs)).
 
 For instance, if you want to avoid index for English pages, add `en` as below.
 `<meta name="robots" content="noindex">` tag will be inserted inside `head` tag
@@ -515,6 +516,28 @@ no_index_langs[] = en
 ```json
 {
   "no_index_langs": ["en"]
+}
+```
+
+#### `no_hreflang_langs`
+
+This parameter tells WOVN.php which languages should not have `hreflang` tags emitted (used for SEO).
+
+```html
+<link rel="alternate" hreflang="en" href="https://my-website.com/en/">
+```
+
+`wovn.ini`
+
+```ini
+no_hreflang_langs[] = en
+```
+
+`wovn.json`
+
+```json
+{
+  "no_hreflang_langs": ["en"]
 }
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -499,7 +499,7 @@ ignore_class[] = no-translate
 
 #### `no_hreflang_langs`
 
-This parameter tells WOVN.php which languages should not have `hreflang` tags emitted (used for SEO).
+This parameter tells WOVN.php which languages should not have `hreflang` tags embedded (used for SEO).
 
 ```html
 <link rel="alternate" hreflang="en" href="https://my-website.com/en/">
@@ -522,7 +522,7 @@ no_hreflang_langs[] = en
 #### `no_index_langs`
 
 This parameter tells WOVN.php which languages's HTML should be set `noindex`
-to avoid index by web crawler. It also prevents `hreflang` tags from being emitted (see [no_hreflang_langs](#no_hreflang_langs)).
+to avoid index by web crawler. It also prevents `hreflang` tags from being embedded (see [no_hreflang_langs](#no_hreflang_langs)).
 
 For instance, if you want to avoid index for English pages, add `en` as below.
 `<meta name="robots" content="noindex">` tag will be inserted inside `head` tag

--- a/README.ja.md
+++ b/README.ja.md
@@ -348,6 +348,7 @@ NOT SUPPORTED
 | [ignore_regex](#ignore_regex)        | all                            | ライブラリ適用対象外URLを正規表現で設定 |
 | [ignore_class](#ignore_class)        | all                            | ライブラリ翻訳対象外とするHTMLのclassを設定 |
 | [no_index_langs](#no_index_langs)    | all                            | SEO対策のタグ適用をしない言語を設定    |
+| [no_hreflang_langs](#no_hreflang_langs)    | all                            | SEO対策のタグ適用をしない言語を設定    |
 | [encoding](#encoding)                | all                            | HTMLの文字エンコーディングを指定       |
 | [api_timeout](#api_timeout)          | all                            | ライブラリの翻訳処理にかかる上限時間を設定 |
 | [disable_api_request_for_default_lang](#disable_api_request_for_default_lang)| all | 元言語アクセス時の翻訳サーバーへのアクセスの要否を設定 |
@@ -502,6 +503,27 @@ ignore_class[] = no-translate
 ```
 
 #### `no_index_langs`
+
+このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
+
+例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。
+`<meta name="robots" content="noindex">` タグは英語ページの場合、`head` タグの中に挿入されます。
+
+`wovn.ini`
+
+```ini
+no_index_langs[] = en
+```
+
+`wovn.json`
+
+```json
+{
+  "no_index_langs": ["en"]
+}
+```
+
+#### `no_hreflang_langs`
 
 このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -347,8 +347,8 @@ NOT SUPPORTED
 | [ignore_paths](#ignore_paths)        | all                            | ライブラリ適用対象外URLをパスで設定    |
 | [ignore_regex](#ignore_regex)        | all                            | ライブラリ適用対象外URLを正規表現で設定 |
 | [ignore_class](#ignore_class)        | all                            | ライブラリ翻訳対象外とするHTMLのclassを設定 |
-| [no_index_langs](#no_index_langs)    | all                            | SEO対策のタグ適用をしない言語を設定    |
-| [no_hreflang_langs](#no_hreflang_langs)    | all                            | SEO対策のタグ適用をしない言語を設定    |
+| [no_index_langs](#no_index_langs)    | all                            | 検索インデックスを防ぎ、指定した言語はSEO最適化タグを埋め込みません    |
+| [no_hreflang_langs](#no_hreflang_langs)    | all                            | SEO最適化タグの埋め込みをしない言語を設定    |
 | [encoding](#encoding)                | all                            | HTMLの文字エンコーディングを指定       |
 | [api_timeout](#api_timeout)          | all                            | ライブラリの翻訳処理にかかる上限時間を設定 |
 | [disable_api_request_for_default_lang](#disable_api_request_for_default_lang)| all | 元言語アクセス時の翻訳サーバーへのアクセスの要否を設定 |
@@ -502,6 +502,27 @@ ignore_class[] = no-translate
 }
 ```
 
+#### `no_hreflang_langs`
+
+このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
+
+例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。
+`<meta name="robots" content="noindex">` タグは英語ページの場合、`head` タグの中に挿入されます。
+
+`wovn.ini`
+
+```ini
+no_index_langs[] = en
+```
+
+`wovn.json`
+
+```json
+{
+  "no_index_langs": ["en"]
+}
+```
+
 #### `no_index_langs`
 
 このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
@@ -523,26 +544,6 @@ no_index_langs[] = en
 }
 ```
 
-#### `no_hreflang_langs`
-
-このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
-
-例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。
-`<meta name="robots" content="noindex">` タグは英語ページの場合、`head` タグの中に挿入されます。
-
-`wovn.ini`
-
-```ini
-no_index_langs[] = en
-```
-
-`wovn.json`
-
-```json
-{
-  "no_index_langs": ["en"]
-}
-```
 
 #### `encoding`
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -504,23 +504,16 @@ ignore_class[] = no-translate
 
 #### `no_hreflang_langs`
 
-このパラメータは、ウェブクローラーによるインデックスを避けるために、どの言語のHTMLを `noindex` に設定すべきかをWOVN.phpに指示します。
+SEO最適化タグの埋め込みをしない言語を設定
 
-例えば、英語ページのインデックスを避けたい場合は、以下のように `en` を追加します。
-`<meta name="robots" content="noindex">` タグは英語ページの場合、`head` タグの中に挿入されます。
+```html
+<link rel="alternate" hreflang="en" href="https://my-website.com/en/">
+```
 
 `wovn.ini`
 
 ```ini
-no_index_langs[] = en
-```
-
-`wovn.json`
-
-```json
-{
-  "no_index_langs": ["en"]
-}
+no_hreflang_langs[] = en
 ```
 
 #### `no_index_langs`

--- a/docker/HOWTO.md
+++ b/docker/HOWTO.md
@@ -130,3 +130,7 @@ Don't forget to configure the followings.
 
 ### Change directory of WordPress files
 You can change WordPress files directory with `working_dir: /var/www/html/anywhere` in `wp_apache.yml`.
+
+## Local equalizer/API setup
+1. Change `widget_url` to your local equalizer URL e.g. `https://j.dev-wovn.io/1`
+2. Change `api_url` to your local HTML swapper URL e.g. `http://host.docker.internal:3001`

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.18.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.19.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -164,6 +164,11 @@ class HtmlConverter
         return in_array($lang, $this->store->settings['no_index_langs']);
     }
 
+    private function isNoHreflangLang($lang)
+    {
+        return in_array($lang, $this->store->settings['no_hreflang_langs']);
+    }
+
     private function insertHtmlLangAttribute($html, $lang_code)
     {
         if (preg_match('/<html\s?.*?>/', $html, $matches)) {
@@ -264,7 +269,7 @@ class HtmlConverter
 
         $hreflangTags = array();
         foreach ($lang_codes as $lang_code) {
-            if ($this->isNoindexLang($lang_code)) {
+            if ($this->isNoindexLang($lang_code) || $this->isNoHreflangLang($lang_code)) {
                 continue;
             }
             $href = $this->buildHrefLang($lang_code);

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -66,6 +66,9 @@ class API
         if (count($store->settings['no_index_langs']) > 0) {
             $data['no_index_langs'] = json_encode($store->settings['no_index_langs']);
         }
+        if (count($store->settings['no_hreflang_langs']) > 0) {
+            $data['no_hreflang_langs'] = json_encode($store->settings['no_hreflang_langs']);
+        }
         if (!empty($store->settings['site_prefix_path'])) {
             $data['site_prefix_path'] = $store->settings['site_prefix_path'];
         }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -153,13 +153,13 @@ class Store
             $this->settings['custom_lang_aliases'] = array();
         } else {
             if (isset($this->settings['supported_langs'])) {
-                $this->convertLangListToOriginalCodes($this->settings['supported_langs']);
+                $this->settings['supported_langs'] = $this->convertLangListToOriginalCodes($this->settings['supported_langs']);
             }
             if (isset($this->settings['no_index_langs'])) {
-                $this->convertLangListToOriginalCodes($this->settings['no_index_langs']);
+                $this->settings['no_index_langs'] = $this->convertLangListToOriginalCodes($this->settings['no_index_langs']);
             }
             if (isset($this->settings['no_hreflang_langs'])) {
-                $this->convertLangListToOriginalCodes($this->settings['no_hreflang_langs']);
+                $this->settings['no_hreflang_langs'] = $this->convertLangListToOriginalCodes($this->settings['no_hreflang_langs']);
             }
         }
 
@@ -211,11 +211,12 @@ class Store
         return $this->settings;
     }
 
-    private function convertLangListToOriginalCodes(&$langListSetting)
+    private function convertLangListToOriginalCodes($langListArray)
     {
-        foreach ($langListSetting as $index => $langCode) {
-            $langListSetting[$index] = $this->convertToOriginalCode($langCode);
+        foreach ($langListArray as $index => $langCode) {
+            $langListArray[$index] = $this->convertToOriginalCode($langCode);
         }
+        return $langListArray
     }
 
     public function convertToCustomLangCode($lang_code)

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -211,7 +211,7 @@ class Store
         return $this->settings;
     }
 
-    private function convertLangListToOriginalCodes($langListSetting)
+    private function convertLangListToOriginalCodes(&$langListSetting)
     {
         foreach ($langListSetting as $index => $langCode) {
             $langListSetting[$index] = $this->convertToOriginalCode($langCode);

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -88,6 +88,7 @@ class Store
             'ignore_regex' => array(),
             'ignore_class' => array(),
             'no_index_langs' => array(),
+            'no_hreflang_langs' => array(),
             'insert_hreflangs' => true,
             'translate_canonical_tag' => true,
             'site_prefix_path' => null,
@@ -152,10 +153,13 @@ class Store
             $this->settings['custom_lang_aliases'] = array();
         } else {
             if (isset($this->settings['supported_langs'])) {
-                $this->ensureValidSupportedLanguages();
+                $this->convertLangListToOriginalCodes($this->settings['supported_langs']);
             }
             if (isset($this->settings['no_index_langs'])) {
-                $this->ensureValidNoIndexLangs();
+                $this->convertLangListToOriginalCodes($this->settings['no_index_langs']);
+            }
+            if (isset($this->settings['no_hreflang_langs'])) {
+                $this->convertLangListToOriginalCodes($this->settings['no_hreflang_langs']);
             }
         }
 
@@ -207,17 +211,9 @@ class Store
         return $this->settings;
     }
 
-    private function ensureValidSupportedLanguages()
-    {
-        foreach ($this->settings['supported_langs'] as $index => $langCode) {
-            $this->settings['supported_langs'][$index] = $this->convertToOriginalCode($langCode);
-        }
-    }
-
-    private function ensureValidNoIndexLangs()
-    {
-        foreach ($this->settings['no_index_langs'] as $index => $langCode) {
-            $this->settings['no_index_langs'][$index] = $this->convertToOriginalCode($langCode);
+    private function convertLangListToOriginalCodes($langListSetting) {
+        foreach ($langListSetting as $index => $langCode) {
+            $langListSetting[$index] = $this->convertToOriginalCode($langCode);
         }
     }
 

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -211,7 +211,8 @@ class Store
         return $this->settings;
     }
 
-    private function convertLangListToOriginalCodes($langListSetting) {
+    private function convertLangListToOriginalCodes($langListSetting)
+    {
         foreach ($langListSetting as $index => $langCode) {
             $langListSetting[$index] = $this->convertToOriginalCode($langCode);
         }

--- a/test/fixtures/basic_html/insert_hreflang_expected_multi_nohreflang_langs.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_multi_nohreflang_langs.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><link rel="alternate" hreflang="zh-Hant" href="http://my-site.com/ct/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/fixtures/basic_html/insert_hreflang_expected_nohreflang_langs.html
+++ b/test/fixtures/basic_html/insert_hreflang_expected_nohreflang_langs.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><link rel="alternate" hreflang="zh-Hant" href="http://my-site.com/ct/"><link rel="alternate" hreflang="zh-Hans" href="http://my-site.com/cs/"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=path&amp;langCodeAliases={&quot;en&quot;:&quot;en&quot;,&quot;zh-CHS&quot;:&quot;cs&quot;,&quot;zh-CHT&quot;:&quot;ct&quot;}&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" async></script>
+    <meta charset="UTF-8">
+    <title>hello</title>
+</head>
+<body>
+world
+</body>
+</html>

--- a/test/integration/UrlQueryPatternTest.php
+++ b/test/integration/UrlQueryPatternTest.php
@@ -384,4 +384,29 @@ class UrlQueryPatternTest extends TestCase
         $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/index.html')->body);
         $this->assertEquals('<html><head></head><body>html-swapper-mock</body></html>', TestUtils::fetchURL('http://localhost/index.html?wovn=ja')->body);
     }
+
+    public function testQueryPatternWithNoHreflangLangs()
+    {
+        $langs = array('en', 'ja');
+        copy("{$this->sourceDir}/wovn_index_sample.php", "{$this->docRoot}/wovn_index.php");
+        TestUtils::writeFile("{$this->docRoot}/index.html", '<html><head></head><body>root</body></html>');
+        TestUtils::setWovnIni("{$this->docRoot}/wovn.ini", array(
+            'url_pattern_name' => 'query',
+            'supported_langs' => $langs,
+            'no_hreflang_langs' => array('en')
+        ));
+
+        $content_without_html_swapper = '<html lang="en">'.
+        '<head>'.
+        '<link rel="alternate" hreflang="ja" href="http://localhost/index.html?wovn=ja">'.
+        '<script src="//j.wovn.io/1" '.
+        'data-wovnio="key=TOKEN&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" '.
+        'data-wovnio-info="version=WOVN.php_VERSION" '.
+        'async></script>'.
+        '</head>'.
+        '<body>root</body>'.
+        '</html>';
+        $this->assertEquals($content_without_html_swapper, TestUtils::fetchURL('http://localhost/index.html')->body);
+        $this->assertEquals('<html><head></head><body>html-swapper-mock</body></html>', TestUtils::fetchURL('http://localhost/index.html?wovn=ja')->body);
+    }
 }

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -195,6 +195,32 @@ class APITest extends TestCase
         $this->assertEquals($this->getExpectedData($store, $headers, $expected_html_before_send, array('no_index_langs' => json_encode(array('en')))), $data, "should contain extra setting");
     }
 
+    public function testTranslateWithNoHreflangLangs()
+    {
+        $settings = array('no_hreflang_langs' => array('en'));
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+
+        $original_html = '<html><head></head><body><h1>en</h1></body></html>';
+        $responsed_html = '<html><head></head><body><h1>response from html-swapper</h1></body></html>';
+        $expected_head_content = $this->getExpectedHtmlHeadContent($store, $headers);
+        $expected_html_before_send = '<html lang="en">'.
+        '<head>'.
+        '<script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async></script>'.
+        '</head>'.
+        '<body><h1>en</h1>'.
+        '</body></html>';
+        $response = json_encode(array("body" => $responsed_html));
+        $mock = $this->mockTranslationApi($response);
+        $request_options = new RequestOptions(array(), false);
+
+        $result = API::translate($store, $headers, $original_html, $request_options);
+
+        $this->assertEquals(1, count($mock->arguments));
+        list($method, $url, $data, $timeout) = $mock->arguments[0];
+        $this->assertEquals($this->getExpectedApiUrl($store, $headers, $expected_html_before_send, $request_options), $url);
+        $this->assertEquals($this->getExpectedData($store, $headers, $expected_html_before_send, array('no_hreflang_langs' => json_encode(array('en')))), $data, "should contain extra setting");
+    }
+
     public function testTranslateWithCustomLangAliases()
     {
         $settings = array('custom_lang_aliases' => array('ja' => 'ja-test'));

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -185,6 +185,24 @@ class StoreTest extends TestCase
         $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
     }
 
+    public function testNoHreflangLangs()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode("\n", array(
+            'project_token = "T0k3N"',
+            'default_lang = "English"',
+            'no_hreflang_langs[] = en',
+            'no_hreflang_langs[] = fr'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals(array('en', 'fr'), $store->settings['no_hreflang_langs']);
+    }
+
     public function testSitePrefixPath()
     {
         $testCases = array(

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -1417,6 +1417,27 @@ bye
         $this->assertEquals($expected_html_text, $translated_html);
     }
 
+    public function testInsertHreflangWithNoHreflangLangs()
+    {
+        libxml_use_internal_errors(true);
+        $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+        $settings = array(
+            'default_lang' => 'en',
+            'supported_langs' => array('en', 'zh-CHT', 'zh-CHS'),
+            'custom_lang_aliases' => array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct'),
+            'url_pattern_name' => 'path',
+            'lang_param_name' => 'wovn',
+            'no_hreflang_langs' => array('en')
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndLangTags($html, false);
+
+        $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_nohreflang_langs.html');
+
+        $this->assertEquals($expected_html_text, $translated_html);
+    }
+
     public function testInsertHreflangWithMultiNoindexLangs()
     {
         libxml_use_internal_errors(true);
@@ -1434,6 +1455,26 @@ bye
         $translated_html = $converter->insertSnippetAndLangTags($html, false);
 
         $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_multi_noindex_langs.html');
+        $this->assertEquals($expected_html_text, $translated_html);
+    }
+
+    public function testInsertHreflangWithMultiNoHreflangLangs()
+    {
+        libxml_use_internal_errors(true);
+        $html = file_get_contents('test/fixtures/basic_html/insert_hreflang_default_lang_alias.html');
+        $settings = array(
+            'default_lang' => 'en',
+            'supported_langs' => array('en', 'zh-CHT', 'zh-CHS'),
+            'custom_lang_aliases' => array('en' => 'en', 'zh-CHS' => 'cs', 'zh-CHT' => 'ct'),
+            'url_pattern_name' => 'path',
+            'lang_param_name' => 'wovn',
+            'no_hreflang_langs' => array('en', 'cs', 'fr')
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+        $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
+        $translated_html = $converter->insertSnippetAndLangTags($html, false);
+
+        $expected_html_text = file_get_contents('test/fixtures/basic_html/insert_hreflang_expected_multi_nohreflang_langs.html');
         $this->assertEquals($expected_html_text, $translated_html);
     }
 


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-1887
### Comments
Needed to allow a new scenario with `custom_domain` where the default lang is not configured and will never be accessed by users. `no_hreflang_langs` acts the same as `no_index_langs` except it will not add a `noindex` tag

```
    "url_pattern_name": "custom_domain",
    "custom_domain_langs": {
        "ja": {
            "source": "local-php.com/japanese",
            "url": "local-php.com/japanese"
        },
        "fr": {
            "source": "local-php.com/french",
            "url": "local-php.com/french"
        }
    },
    "default_lang": "en",
    "supported_langs": [
        "ja",
        "fr"
    ],
    "no_hreflang_langs": [
        "en"
    ],
```

Related PRs: https://github.com/WOVNio/html-swapper/pull/877 https://github.com/WOVNio/equalizer/pull/53371
### Release comments (new feature)
