### PR TITLE
fix: Fix test for older PHP versions

### DIFF
--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -4,7 +4,7 @@ ARG DOCKER_IMAGE
 
 # apt-get doesn't work for OS which depends on jessie.
 # So, change apt-get targets.
-RUN bash -c 'if [[ "${DOCKER_IMAGE}" =~ ^.*php:?5\.[3-4].*$ ]]; then \
+RUN bash -c 'if [[ "${DOCKER_IMAGE}" =~ ^.*php:?(5\.[3-6]|7\.0).*$ ]]; then \
     echo "deb http://archive.debian.org/debian/ stretch main" > "/etc/apt/sources.list"; \
     echo "deb http://archive.debian.org/debian-security stretch/updates main" >> "/etc/apt/sources.list"; \
 fi'

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -5,8 +5,8 @@ ARG DOCKER_IMAGE
 # apt-get doesn't work for OS which depends on jessie.
 # So, change apt-get targets.
 RUN bash -c 'if [[ "${DOCKER_IMAGE}" =~ ^.*php:?5\.[3-4].*$ ]]; then \
-    echo "deb http://deb.debian.org/debian jessie main" > "/etc/apt/sources.list"; \
-    echo "deb http://security.debian.org jessie/updates main" >> "/etc/apt/sources.list"; \
+    echo "deb http://archive.debian.org/debian/ stretch main" > "/etc/apt/sources.list"; \
+    echo "deb http://archive.debian.org/debian-security stretch/updates main" >> "/etc/apt/sources.list"; \
 fi'
 
 RUN apt-get autoclean


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
Some PHP version tests start failing because of test environment setup.
https://app.circleci.com/pipelines/github/WOVNio/WOVN.php/825/workflows/277cc41e-687d-4337-9548-db816fdc5f85

`apt-get` command doesn't work for OS which depends on jessie. The following command update targets of apt-get.
```
echo "deb http://deb.debian.org/debian jessie main" > "/etc/apt/sources.list"; \
echo "deb http://security.debian.org jessie/updates main" >> "/etc/apt/sources.list"; \
```

It seems the targets were updated. This PR changed to refer archived packages. Like the followings.
```
echo "deb http://archive.debian.org/debian/ stretch main" > "/etc/apt/sources.list"; \
echo "deb http://archive.debian.org/debian-security stretch/updates main" >> "/etc/apt/sources.list"; \
```

### Comments

### Release comments (new feature)
