### PR TITLE
feat: [SUP-2248] Add support for `HTTP_CLOUDFRONT_FORWARDED_PROTO`

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.20.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.21.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -37,7 +37,7 @@ class Headers
         $this->cookieLang = $cookieLang;
         if ($store->settings['use_proxy'] && isset($env['HTTP_CLOUDFRONT_FORWARDED_PROTO'])) {
             $this->protocol = $env['HTTP_CLOUDFRONT_FORWARDED_PROTO'];
-        } else if ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_PROTO'])) {
+        } elseif ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_PROTO'])) {
             $this->protocol = $env['HTTP_X_FORWARDED_PROTO'];
         } else {
             if (isset($env['HTTPS']) && !empty($env['HTTPS']) && $env['HTTPS'] !== 'off') {

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -35,7 +35,9 @@ class Headers
         $this->env =& $env;
         $this->store =& $store;
         $this->cookieLang = $cookieLang;
-        if ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_PROTO'])) {
+        if ($store->settings['use_proxy'] && isset($env['HTTP_CLOUDFRONT_FORWARDED_PROTO'])) {
+            $this->protocol = $env['HTTP_CLOUDFRONT_FORWARDED_PROTO'];
+        } else if ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_PROTO'])) {
             $this->protocol = $env['HTTP_X_FORWARDED_PROTO'];
         } else {
             if (isset($env['HTTPS']) && !empty($env['HTTPS']) && $env['HTTPS'] !== 'off') {

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -62,7 +62,7 @@ class HeadersTest extends TestCase
         $settings = array('use_proxy' => 1);
         $env = array(
             'HTTP_X_FORWARDED_HOST' => 'ja.wovn.io',
-            'HTTP_X_FORWARDED_PROTO' => 'http',  
+            'HTTP_X_FORWARDED_PROTO' => 'http',
             'HTTP_CLOUDFRONT_FORWARDED_PROTO' => 'https'
         );
         list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -57,6 +57,21 @@ class HeadersTest extends TestCase
         $this->assertEquals('http', $headers->protocol);
     }
 
+    public function testHeadersWithUseProxyTrueAndCloudFrontProto()
+    {
+        $settings = array('use_proxy' => 1);
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => 'ja.wovn.io',
+            'HTTP_X_FORWARDED_PROTO' => 'http',  
+            'HTTP_CLOUDFRONT_FORWARDED_PROTO' => 'https'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('ja.wovn.io', $headers->originalHost);
+        $this->assertEquals('ja.wovn.io', $headers->host);
+        $this->assertEquals('https', $headers->protocol);
+    }
+
     public function testHeadersWithUseProxyTrueButNoForwardedInfo()
     {
         $settings = array('use_proxy' => 1);


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

https://wovnio.atlassian.net/browse/SUP-2248

Adds support for `CloudFront-Forwarded-Proto` header, which CloudFront uses instead of `X-Forwarded-Proto`.

Ref.: [Amazon CloudFront docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior)

### Comments

### Release comments (new feature)
