### PR TITLE
fix: [ST-2184] Hidden input with "0" value is not ignored

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.21.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.21.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -415,7 +415,7 @@ class HtmlConverter
 
         if (strtolower($node->tag) === 'input' && strtolower($node->getAttribute('type')) == 'hidden') {
             $originalText = $node->getAttribute('value');
-            if ($originalText === false || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
+            if ((!$originalText && $originalText !== '0') || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
                 return;
             }
 

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -415,7 +415,7 @@ class HtmlConverter
 
         if (strtolower($node->tag) === 'input' && strtolower($node->getAttribute('type')) == 'hidden') {
             $originalText = $node->getAttribute('value');
-            if (strlen($originalText) < 1 || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
+            if ($originalText === false || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
                 return;
             }
 

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -415,7 +415,7 @@ class HtmlConverter
 
         if (strtolower($node->tag) === 'input' && strtolower($node->getAttribute('type')) == 'hidden') {
             $originalText = $node->getAttribute('value');
-            if (!$originalText || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
+            if ($originalText === false || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
                 return;
             }
 

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -415,7 +415,7 @@ class HtmlConverter
 
         if (strtolower($node->tag) === 'input' && strtolower($node->getAttribute('type')) == 'hidden') {
             $originalText = $node->getAttribute('value');
-            if ((!$originalText && $originalText !== '0') || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
+            if (strlen($originalText) < 1 || strpos($originalText, HtmlReplaceMarker::$keyPrefix) !== false) {
                 return;
             }
 

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -286,7 +286,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if ($val || $val === '0') {
+        if (strlen($val) > 0) {
             return $this->convert_text($val);
         }
 

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -286,7 +286,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if (strlen($val) > 0) {
+        if ($val !== false) {
             return $this->convert_text($val);
         }
 

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -286,7 +286,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if ($val) {
+        if ($val !== '') {
             return $this->convert_text($val);
         }
 

--- a/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
+++ b/src/wovnio/modified_vendor/SimpleHtmlDomNode.php
@@ -286,7 +286,7 @@ class SimpleHtmlDomNode {
     {
         $val = $this->get_attr_val($this->attribute, $name);
 
-        if ($val !== '') {
+        if ($val || $val === '0') {
             return $this->convert_text($val);
         }
 

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -884,6 +884,15 @@ class HtmlConverterTest extends TestCase
 
                 '<html><head></head><body><input type="hidden"></body></html>',
             ),
+            array(
+                '<input> with 0 value',
+
+                '<html><head></head><body><input type="hidden" value="0"></body></html>',
+
+                '<html><head></head><body><input type="hidden" value="__wovn-backend-ignored-key-0"></body></html>',
+
+                '<html><head></head><body><input type="hidden" value="0"></body></html>',
+            ),
         );
         $settings = array(
             'supported_langs' => array('en', 'vi'),

--- a/test/unit/modified_vendor/SimpleHtmlDomTest.php
+++ b/test/unit/modified_vendor/SimpleHtmlDomTest.php
@@ -21,6 +21,7 @@ class SimpleHtmlDomTest extends TestCase
             ' data-dummy-4=""'.
             ' data-dummy-5=\'\''.
             ' data-dummy-6'.
+            ' data-dummy-7="0"'.
             '></div>'.
             '</body></html>';
         $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
@@ -33,6 +34,8 @@ class SimpleHtmlDomTest extends TestCase
         $this->assertEquals('', $nodes[0]->getAttribute('data-dummy-4'));
         $this->assertEquals('', $nodes[0]->getAttribute('data-dummy-5'));
         $this->assertEquals(true, $nodes[0]->getAttribute('data-dummy-6'));
+        $this->assertEquals('0', $nodes[0]->getAttribute('data-dummy-7'));
+        $this->assertEquals(false, $nodes[0]->getAttribute('data-dummy-8'));
     }
 
     public function testSetAttribute()

--- a/test/unit/modified_vendor/SimpleHtmlDomTest.php
+++ b/test/unit/modified_vendor/SimpleHtmlDomTest.php
@@ -22,6 +22,7 @@ class SimpleHtmlDomTest extends TestCase
             ' data-dummy-5=\'\''.
             ' data-dummy-6'.
             ' data-dummy-7="0"'.
+            ' data-dummy-8="false"'.
             '></div>'.
             '</body></html>';
         $dom = SimpleHtmlDom::str_get_html($html, 'UTF-8', false, false, 'UTF-8', false);
@@ -35,7 +36,8 @@ class SimpleHtmlDomTest extends TestCase
         $this->assertEquals('', $nodes[0]->getAttribute('data-dummy-5'));
         $this->assertEquals(true, $nodes[0]->getAttribute('data-dummy-6'));
         $this->assertEquals('0', $nodes[0]->getAttribute('data-dummy-7'));
-        $this->assertEquals(false, $nodes[0]->getAttribute('data-dummy-8'));
+        $this->assertEquals('false', $nodes[0]->getAttribute('data-dummy-8'));
+        $this->assertEquals(false, $nodes[0]->getAttribute('data-dummy-9'));
     }
 
     public function testSetAttribute()


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

Fixes logic where `0` is not ignored and sent to html-swapper as-is.

Before (text sent to html-swapper):
```
<input type="hidden" value="0">
```

After:
```
<input type="hidden" value="__wovn-backend-ignored-key-${SOME_INCREMENTAL_KEY}">
```

### Comments

PHP considers `'0'` string as `false` when converted to boolean (ref. [docs](https://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting)).

### Release comments (new feature)
