### PR TITLE
feature: [ST-2232] support meta refresh tags

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.21.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.22.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -378,7 +378,7 @@ class HtmlConverter
      * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
      * Use `_` prefix to imply `private`
      */
-    private function _translateMetaTagLink($meta_node)
+    public function _translateMetaTagLink($meta_node)
     {
         $httpEquiv = $meta_node->getAttribute('http-equiv');
         $metaContent = $meta_node->getAttribute('content');
@@ -389,7 +389,7 @@ class HtmlConverter
                 $refreshTime= $splitMetaContent[0];
                 $separator = $splitMetaContent[1]; // url=
                 $url = $splitMetaContent[2];
-                
+
                 $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
                 $newMetaContent = $refreshTime . ";$separator=" . $translatedUrl;
                 $meta_node->setAttribute('content', $newMetaContent);

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -384,11 +384,14 @@ class HtmlConverter
         $metaContent = $meta_node->getAttribute('content');
 
         if ($httpEquiv === 'refresh') {
-            $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
-            if (count($splitMetaContent) === 2) {
-                $url = $splitMetaContent[1];
+            $splitMetaContent = preg_split('/;(\s*url)=/i', $metaContent, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+            if (count($splitMetaContent) === 3) {
+                $refreshTime= $splitMetaContent[0];
+                $separator = $splitMetaContent[1]; // url=
+                $url = $splitMetaContent[2];
+                
                 $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
-                $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
+                $newMetaContent = $refreshTime . ";$separator=" . $translatedUrl;
                 $meta_node->setAttribute('content', $newMetaContent);
             }
         }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -114,6 +114,10 @@ class HtmlConverter
             } elseif (strtolower($node->tag) == "body") {
                 $body = $node;
             }
+            
+            if ($node->tag === 'meta') {
+                $self->_translateMetaTagLink($node);
+            }
             $self->_removeWovnIgnore($node, $marker);
             $self->_removeCustomIgnoreClass($node, $marker);
             $self->_removeForm($node, $marker);
@@ -136,6 +140,19 @@ class HtmlConverter
         $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
         return $this->insertAfterTag($parent_tags, $html, $snippet_code);
+    }
+
+    private function _translateMetaTagLink($meta_node)
+    {
+        $httpEquiv = $meta_node->getAttribute('http-equiv');
+        $metaContent = $meta_node->getAttribute('content')
+        $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
+        if (count($splitMetaContent) === 2) {
+            $url = $splitMetaContent[1];
+            $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
+            $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
+            $meta_node->setAttribute('content', $newMetaContent);
+        }
     }
 
     private function removeSnippet($html)

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -116,7 +116,7 @@ class HtmlConverter
             }
             
             if ($node->tag === 'meta') {
-                $self->translateMetaTagLink($node);
+                $self->_translateMetaTagLink($node);
             }
             $self->_removeWovnIgnore($node, $marker);
             $self->_removeCustomIgnoreClass($node, $marker);
@@ -140,22 +140,6 @@ class HtmlConverter
         $parent_tags = array("(<head\s?.*?>)", "(<body\s?.*?>)", "(<html\s?.*?>)");
 
         return $this->insertAfterTag($parent_tags, $html, $snippet_code);
-    }
-
-    private function translateMetaTagLink($meta_node)
-    {
-        $httpEquiv = $meta_node->getAttribute('http-equiv');
-        $metaContent = $meta_node->getAttribute('content');
-
-        if ($httpEquiv === 'refresh') {
-            $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
-            if (count($splitMetaContent) === 2) {
-                $url = $splitMetaContent[1];
-                $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
-                $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
-                $meta_node->setAttribute('content', $newMetaContent);
-            }
-        }
     }
 
     private function removeSnippet($html)
@@ -393,6 +377,26 @@ class HtmlConverter
     /**
      * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
      * Use `_` prefix to imply `private`
+     */
+    private function _translateMetaTagLink($meta_node)
+    {
+        $httpEquiv = $meta_node->getAttribute('http-equiv');
+        $metaContent = $meta_node->getAttribute('content');
+
+        if ($httpEquiv === 'refresh') {
+            $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
+            if (count($splitMetaContent) === 2) {
+                $url = $splitMetaContent[1];
+                $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
+                $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
+                $meta_node->setAttribute('content', $newMetaContent);
+            }
+        }
+    }
+
+    /**
+     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
+     * Use `_` prefix to imply `private`
      *
      * @param SimpleHtmlDomNode $node
      * @param HtmlReplaceMarker $marker
@@ -404,6 +408,10 @@ class HtmlConverter
         }
     }
 
+    /**
+     * Note: Because php5.3 doesn't allow calling private method inside anonymous function,
+     * Use `_` prefix to imply `private`
+     */
     public function _removeCustomIgnoreClass($node, $marker)
     {
         $class_attr = $node->getAttribute('class');

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -146,12 +146,15 @@ class HtmlConverter
     {
         $httpEquiv = $meta_node->getAttribute('http-equiv');
         $metaContent = $meta_node->getAttribute('content');
-        $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
-        if (count($splitMetaContent) === 2) {
-            $url = $splitMetaContent[1];
-            $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
-            $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
-            $meta_node->setAttribute('content', $newMetaContent);
+
+        if ($httpEquiv === 'refresh') {
+            $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
+            if (count($splitMetaContent) === 2) {
+                $url = $splitMetaContent[1];
+                $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
+                $newMetaContent = $splitMetaContent[0] . ';url=' . $translatedUrl;
+                $meta_node->setAttribute('content', $newMetaContent);
+            }
         }
     }
 

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -116,7 +116,7 @@ class HtmlConverter
             }
             
             if ($node->tag === 'meta') {
-                $self->_translateMetaTagLink($node);
+                $self->translateMetaTagLink($node);
             }
             $self->_removeWovnIgnore($node, $marker);
             $self->_removeCustomIgnoreClass($node, $marker);
@@ -142,7 +142,7 @@ class HtmlConverter
         return $this->insertAfterTag($parent_tags, $html, $snippet_code);
     }
 
-    private function _translateMetaTagLink($meta_node)
+    private function translateMetaTagLink($meta_node)
     {
         $httpEquiv = $meta_node->getAttribute('http-equiv');
         $metaContent = $meta_node->getAttribute('content');

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -384,14 +384,14 @@ class HtmlConverter
         $metaContent = $meta_node->getAttribute('content');
 
         if ($httpEquiv === 'refresh') {
-            $splitMetaContent = preg_split('/;(\s*url)=/i', $metaContent, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-            if (count($splitMetaContent) === 3) {
-                $refreshTime= $splitMetaContent[0];
-                $separator = $splitMetaContent[1]; // url=
-                $url = $splitMetaContent[2];
+            $splitMetaContent = preg_match('/(.*;\s*url=[\'"]?)([^\s\'"]+)([\'"]?)/i', $metaContent, $matches);
+            if (count($matches) !== 0) {
+                $startStr = $matches[1];
+                $url = $matches[2];
+                $endStr = $matches[3];
 
                 $translatedUrl = Url::addLangCode($url, $this->store, $this->headers->requestLang(), $this->headers);
-                $newMetaContent = $refreshTime . ";$separator=" . $translatedUrl;
+                $newMetaContent = $startStr . $translatedUrl . $endStr;
                 $meta_node->setAttribute('content', $newMetaContent);
             }
         }

--- a/src/wovnio/html/HtmlConverter.php
+++ b/src/wovnio/html/HtmlConverter.php
@@ -145,7 +145,7 @@ class HtmlConverter
     private function _translateMetaTagLink($meta_node)
     {
         $httpEquiv = $meta_node->getAttribute('http-equiv');
-        $metaContent = $meta_node->getAttribute('content')
+        $metaContent = $meta_node->getAttribute('content');
         $splitMetaContent = preg_split('/;url=/', $metaContent, null, PREG_SPLIT_NO_EMPTY);
         if (count($splitMetaContent) === 2) {
             $url = $splitMetaContent[1];

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -13,7 +13,9 @@ class Headers
     public $originalUrl;
     public $host;
     public $pathname;
+    public $pathnameKeepTrailingSlash;
     public $url;
+    public $urlKeepTrailingSlash;
     public $query;
 
     private $env;

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLang.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLang.php
@@ -13,7 +13,7 @@ class CustomDomainLang
     public function __construct($host, $path, $lang, $source = null)
     {
         $this->host = $host;
-        $this->path = substr($path, -1) === '/' ? $path : $path . '/';
+        $this->path = substr((string)$path, -1) === '/' ? $path : $path . '/';
         $this->lang = $lang;
         $this->source = $source ? new CustomDomainLangSource($source, $lang) : null;
     }

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -893,6 +893,15 @@ class HtmlConverterTest extends TestCase
 
                 '<html><head></head><body><input type="hidden" value="0"></body></html>',
             ),
+            array(
+                'meta refresh tag - should have url translated',
+
+                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+            ),
         );
         $settings = array(
             'supported_langs' => array('en', 'vi'),

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -894,23 +894,46 @@ class HtmlConverterTest extends TestCase
                 '<html><head></head><body><input type="hidden" value="0"></body></html>',
             ),
             array(
-                'meta refresh tag - should have url translated',
+                'meta http-equiv refresh tag - internal url - should have url translated',
 
-                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+                '<html><head><meta http-equiv="refresh" content="0;url=/redirect"></head><body></body></html>',
 
-                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+                '<html><head><meta http-equiv="refresh" content="0;url=/vi/redirect"></head><body></body></html>',
 
-                '<html><head><meta http-equiv="refresh" content="0;url="/redirect"></head><body></body></html>',
+                '<html><head><meta http-equiv="refresh" content="0;url=/vi/redirect"></head><body></body></html>',
             ),
+            array(
+                'meta http-equiv refresh tag - external url - does nothing',
+
+                '<html><head><meta http-equiv="refresh" content="0;url=https://external.com/redirect"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="refresh" content="0;url=https://external.com/redirect"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="refresh" content="0;url=https://external.com/redirect"></head><body></body></html>',
+            ),
+            array(
+                'meta http-equiv non-refresh tag - does nothing',
+
+                '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body></body></html>',
+
+                '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body></body></html>',
+            )
         );
         $settings = array(
             'supported_langs' => array('en', 'vi'),
             'lang_param_name' => 'wovn',
+            'url_pattern_name' => 'path',
             'ignore_class' => array('ignore-class')
         );
+        $envs = array(
+            'REQUEST_URI' => '/vi/news/'
+        );
+
         foreach ($html_cases as $case) {
             list($message, $original_html, $expected_converted_html, $expected_reverted_html) = $case;
-            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings);
+            list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $envs);
             $converter = new HtmlConverter('UTF-8', $store->settings['project_token'], $store, $headers);
             $converted_html = $converter->convertToAppropriateBodyForApi($original_html, false);
 

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -898,16 +898,22 @@ class HtmlConverterTest extends TestCase
 
                 '<html><head>'.
                 '<meta http-equiv="refresh" content="0;url=/redirect">'.
+                '<meta http-equiv="refresh" content="0;url=\'/redirect\'">'.
+                '<meta http-equiv="refresh" content=\'0;url="/redirect"\'>'.
                 '<meta http-equiv="refresh" content="0; URL=/redirect">'.
                 '</head><body></body></html>',
 
                 '<html><head>'.
                 '<meta http-equiv="refresh" content="0;url=/vi/redirect">'.
+                '<meta http-equiv="refresh" content="0;url=\'/vi/redirect\'">'.
+                '<meta http-equiv="refresh" content=\'0;url="/vi/redirect"\'>'.
                 '<meta http-equiv="refresh" content="0; URL=/vi/redirect">'.
                 '</head><body></body></html>',
 
                 '<html><head>'.
                 '<meta http-equiv="refresh" content="0;url=/vi/redirect">'.
+                '<meta http-equiv="refresh" content="0;url=\'/vi/redirect\'">'.
+                '<meta http-equiv="refresh" content=\'0;url="/vi/redirect"\'>'.
                 '<meta http-equiv="refresh" content="0; URL=/vi/redirect">'.
                 '</head><body></body></html>',
             ),

--- a/test/unit/html/HtmlConverterTest.php
+++ b/test/unit/html/HtmlConverterTest.php
@@ -896,11 +896,20 @@ class HtmlConverterTest extends TestCase
             array(
                 'meta http-equiv refresh tag - internal url - should have url translated',
 
-                '<html><head><meta http-equiv="refresh" content="0;url=/redirect"></head><body></body></html>',
+                '<html><head>'.
+                '<meta http-equiv="refresh" content="0;url=/redirect">'.
+                '<meta http-equiv="refresh" content="0; URL=/redirect">'.
+                '</head><body></body></html>',
 
-                '<html><head><meta http-equiv="refresh" content="0;url=/vi/redirect"></head><body></body></html>',
+                '<html><head>'.
+                '<meta http-equiv="refresh" content="0;url=/vi/redirect">'.
+                '<meta http-equiv="refresh" content="0; URL=/vi/redirect">'.
+                '</head><body></body></html>',
 
-                '<html><head><meta http-equiv="refresh" content="0;url=/vi/redirect"></head><body></body></html>',
+                '<html><head>'.
+                '<meta http-equiv="refresh" content="0;url=/vi/redirect">'.
+                '<meta http-equiv="refresh" content="0; URL=/vi/redirect">'.
+                '</head><body></body></html>',
             ),
             array(
                 'meta http-equiv refresh tag - external url - does nothing',


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-2232
https://github.com/WOVNio/html-swapper/pull/968
### Comments
Some customers are using refresh meta tags to trigger refreshes. We want to translate this redirect URL similar to a normal redirect.

`<meta http-equiv="refresh" content="0;URL=/international/index.html#anchor02">`
### Release comments (new feature)
