### PR TITLE
feature: add outbound_proxy_host/port settings, to support HTTP proxy via curl

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -348,6 +348,8 @@ and should be used for performance optimization.
 | [compress_api_requests](#compress_api_requests)                               | all                       | Enable gzip compression for outbound requests to translation API            |
 | [logging](#logging)                                                           | all                       | Enable and configure error logging                                          |
 | [translate_canonical_tag](#translate_canonical_tag)                           | all                       | Enable the translation of canonical tag URL                                 |
+| [outbound_proxy_host](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy host used to connect to WOVN API 
+| [outbound_proxy_port](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy port used to connect to WOVN API
 
 #### `lang_param_name`
 This parameter is only valid for when `url_pattern_name = query`.
@@ -908,6 +910,26 @@ Example:
 
 ```ini
 translate_canonical_tag = true
+```
+
+#### `outbound_proxy_host / outbound_proxy_port`
+Configures if WOVN.php should make connections to our API using a HTTP proxy.
+`outbound_proxy_host` should be set to the proxy's host. `outbound_proxy_port` should be set to the proxy's port number.
+
+`wovn.json`
+
+```json
+{
+  "outbound_proxy_host": "site.com",
+  "outbound_proxy_port": "8080",
+}
+```
+
+`wovn.ini`
+
+```ini
+outbound_proxy_host = site.com
+outbound_proxy_port = 8080
 ```
 
 ## 4. Environment Variable

--- a/README.en.md
+++ b/README.en.md
@@ -913,7 +913,7 @@ translate_canonical_tag = true
 ```
 
 #### `outbound_proxy_host / outbound_proxy_port`
-Configures if WOVN.php should make connections to our API using a proxy server.
+Configures if WOVN.php should connect to our API using a proxy server.
 `outbound_proxy_host` should be set to the proxy server host. `outbound_proxy_port` should be set to the proxy server port number.
 
 `wovn.json`

--- a/README.en.md
+++ b/README.en.md
@@ -348,8 +348,8 @@ and should be used for performance optimization.
 | [compress_api_requests](#compress_api_requests)                               | all                       | Enable gzip compression for outbound requests to translation API            |
 | [logging](#logging)                                                           | all                       | Enable and configure error logging                                          |
 | [translate_canonical_tag](#translate_canonical_tag)                           | all                       | Enable the translation of canonical tag URL                                 |
-| [outbound_proxy_host](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy host used to connect to WOVN API 
-| [outbound_proxy_port](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy port used to connect to WOVN API
+| [outbound_proxy_host](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy server host used to connect to WOVN API 
+| [outbound_proxy_port](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy server port used to connect to WOVN API
 
 #### `lang_param_name`
 This parameter is only valid for when `url_pattern_name = query`.
@@ -913,8 +913,8 @@ translate_canonical_tag = true
 ```
 
 #### `outbound_proxy_host / outbound_proxy_port`
-Configures if WOVN.php should make connections to our API using a HTTP proxy.
-`outbound_proxy_host` should be set to the proxy's host. `outbound_proxy_port` should be set to the proxy's port number.
+Configures if WOVN.php should make connections to our API using a proxy server.
+`outbound_proxy_host` should be set to the proxy server host. `outbound_proxy_port` should be set to the proxy server port number.
 
 `wovn.json`
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -735,7 +735,7 @@ insert_hreflangs = 1
 ```
 
 #### `outbound_proxy_host / outbound_proxy_port`
-Configures if WOVN.php should make connections to our API using a proxy server.
+Configures if WOVN.php should connect to our API using a proxy server.
 `outbound_proxy_host` should be set to the proxy server host. `outbound_proxy_port` should be set to the proxy server port number.
 
 `wovn.json`

--- a/README.ja.md
+++ b/README.ja.md
@@ -358,7 +358,8 @@ NOT SUPPORTED
 | [site_prefix_path](#site_prefix_path)| path                           | 言語コードの挿入位置を変更            |
 | [custom_domain_langs](#custom_domain_langs)| custom_domain            | サポートされている言語のドメインとパスを定義 |
 | [insert_hreflangs](#custom_domain_langs)| all                         | hreflang属性を持つlinkタグの挿入要否を設定 |
-
+| [outbound_proxy_host](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy server host used to connect to WOVN API 
+| [outbound_proxy_port](#outbound_proxy_host--outbound_proxy_port)               | all                       | HTTP proxy server port used to connect to WOVN API
 
 #### `lang_param_name`
 
@@ -731,6 +732,26 @@ insert_hreflangs = 1
 {
   "insert_hreflangs": true
 }
+```
+
+#### `outbound_proxy_host / outbound_proxy_port`
+Configures if WOVN.php should make connections to our API using a proxy server.
+`outbound_proxy_host` should be set to the proxy server host. `outbound_proxy_port` should be set to the proxy server port number.
+
+`wovn.json`
+
+```json
+{
+  "outbound_proxy_host": "site.com",
+  "outbound_proxy_port": "8080",
+}
+```
+
+`wovn.ini`
+
+```ini
+outbound_proxy_host = site.com
+outbound_proxy_port = 8080
 ```
 
 ## 4. 環境変数

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.22.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.23.0';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -51,7 +51,7 @@ class CurlRequestHandler extends AbstractRequestHandler
 
         $proxy = $this->store->outboundProxy();
         if ($proxy) {
-            $curlOptions['CURLOPT_PROXY'] = $proxy;
+            $curlOptions[CURLOPT_PROXY] = $proxy;
         }
 
         curl_setopt_array($curl_session, $curlOptions);

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -38,7 +38,7 @@ class CurlRequestHandler extends AbstractRequestHandler
         // So, it is better to disable 'Expect: 100-continue'.
         array_push($request_headers, 'Expect:');
 
-        curl_setopt_array($curl_session, array(
+        $curlOptions = array(
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_TIMEOUT => $timeout,
             // adds header to accept GZIP encoding and handles decoding response
@@ -47,7 +47,14 @@ class CurlRequestHandler extends AbstractRequestHandler
             CURLOPT_POSTFIELDS => $data,
             CURLOPT_HEADER => true,
             CURLOPT_HTTPHEADER => $request_headers
-        ));
+        );
+
+        $proxy = $this->store->outboundProxy();
+        if ($proxy) {
+            $curlOptions['CURLOPT_PROXY'] = $proxy;
+        }
+
+        curl_setopt_array($curl_session, $curlOptions);
 
         $response = curl_exec($curl_session);
         $header_size = curl_getinfo($curl_session, CURLINFO_HEADER_SIZE);

--- a/src/wovnio/utils/request_handlers/CurlRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/CurlRequestHandler.php
@@ -49,9 +49,13 @@ class CurlRequestHandler extends AbstractRequestHandler
             CURLOPT_HTTPHEADER => $request_headers
         );
 
-        $proxy = $this->store->outboundProxy();
-        if ($proxy) {
-            $curlOptions[CURLOPT_PROXY] = $proxy;
+        $proxyHost = $this->store->outboundProxyHost();
+        if ($proxyHost) {
+            $curlOptions[CURLOPT_PROXY] = $proxyHost;
+        }
+        $proxyPort = $this->store->outboundProxyPort();
+        if ($proxyPort) {
+            $curlOptions[CURLOPT_PROXYPORT] = $proxyPort;
         }
 
         curl_setopt_array($curl_session, $curlOptions);

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -265,18 +265,17 @@ class Store
         return $this->settings['compress_api_requests'];
     }
 
-    public function outboundProxy()
+    public function outboundProxyHost()
     {
-        $result = null;
+        return isset($this->settings['outbound_proxy_host'])
+            ? $this->settings['outbound_proxy_host']
+            : null;
+    }
 
-        if (isset($this->settings['outbound_proxy_host'])) {
-            $result = $this->settings['outbound_proxy_host'];
-        }
-        if (isset($this->settings['outbound_proxy_port'])) {
-            $port = $this->settings['outbound_proxy_port'];
-            $result .= ":$port";
-        }
-
-        return $result;
+    public function outboundProxyPort()
+    {
+        return isset($this->settings['outbound_proxy_port'])
+            ? $this->settings['outbound_proxy_port']
+            : null;
     }
 }

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -267,7 +267,7 @@ class Store
 
     public function outboundProxy()
     {
-        $result = null
+        $result = null;
 
         if (isset($this->settings['outbound_proxy_host'])) {
             $result = $this->settings['outbound_proxy_host'];

--- a/src/wovnio/wovnphp/Store.php
+++ b/src/wovnio/wovnphp/Store.php
@@ -94,6 +94,10 @@ class Store
             'site_prefix_path' => null,
             'custom_domain_langs' => array(),
 
+            // HTTP proxy used for outbound WOVN requests
+            'outbound_proxy_host' => null,
+            'outbound_proxy_port' => null,
+
             // Set to true to check if intercepted file is an AMP file.
             // Because WOVN.php interception is explicit, in most cases AMP files
             // are not intercepted, so this option is false by default -- always
@@ -259,5 +263,20 @@ class Store
     public function compressApiRequests()
     {
         return $this->settings['compress_api_requests'];
+    }
+
+    public function outboundProxy()
+    {
+        $result = null
+
+        if (isset($this->settings['outbound_proxy_host'])) {
+            $result = $this->settings['outbound_proxy_host'];
+        }
+        if (isset($this->settings['outbound_proxy_port'])) {
+            $port = $this->settings['outbound_proxy_port'];
+            $result .= ":$port";
+        }
+
+        return $result;
     }
 }

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -185,6 +185,52 @@ class StoreTest extends TestCase
         $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
     }
 
+    public function testOutboundProxyNoSettingDefined()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode("\n", array(
+            'outbound_proxy_host = "site.com"'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals(null, $store->outboundProxy());
+    }
+
+    public function testOutboundProxyOnlyHost()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode("\n", array(
+            'outbound_proxy_host = "site.com"'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals('site.com'), $store->outboundProxy());
+    }
+
+    public function testOutboundProxyHostPortDefined()
+    {
+        $file_config = dirname(__FILE__) . '/test_config.ini';
+        if (file_exists($file_config)) {
+            unlink($file_config);
+        }
+        $data = implode("\n", array(
+            'outbound_proxy_host = "site.com"',
+            'outbound_proxy_port = "8080"'
+        ));
+        file_put_contents($file_config, $data);
+        $store = Store::createFromFile($file_config);
+        unlink($file_config);
+        $this->assertEquals('site.com:8080'), $store->outboundProxy());
+    }
+
     public function testNoHreflangLangs()
     {
         $file_config = dirname(__FILE__) . '/test_config.ini';

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -191,9 +191,7 @@ class StoreTest extends TestCase
         if (file_exists($file_config)) {
             unlink($file_config);
         }
-        $data = implode("\n", array(
-            'outbound_proxy_host = "site.com"'
-        ));
+        $data = implode("\n", array());
         file_put_contents($file_config, $data);
         $store = Store::createFromFile($file_config);
         unlink($file_config);
@@ -212,7 +210,7 @@ class StoreTest extends TestCase
         file_put_contents($file_config, $data);
         $store = Store::createFromFile($file_config);
         unlink($file_config);
-        $this->assertEquals('site.com'), $store->outboundProxy());
+        $this->assertEquals('site.com', $store->outboundProxy());
     }
 
     public function testOutboundProxyHostPortDefined()
@@ -228,7 +226,7 @@ class StoreTest extends TestCase
         file_put_contents($file_config, $data);
         $store = Store::createFromFile($file_config);
         unlink($file_config);
-        $this->assertEquals('site.com:8080'), $store->outboundProxy());
+        $this->assertEquals('site.com:8080', $store->outboundProxy());
     }
 
     public function testNoHreflangLangs()

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -185,50 +185,6 @@ class StoreTest extends TestCase
         $this->assertEquals(array('en', 'fr'), $store->settings['no_index_langs']);
     }
 
-    public function testOutboundProxyNoSettingDefined()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array());
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals(null, $store->outboundProxy());
-    }
-
-    public function testOutboundProxyOnlyHost()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array(
-            'outbound_proxy_host = "site.com"'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals('site.com', $store->outboundProxy());
-    }
-
-    public function testOutboundProxyHostPortDefined()
-    {
-        $file_config = dirname(__FILE__) . '/test_config.ini';
-        if (file_exists($file_config)) {
-            unlink($file_config);
-        }
-        $data = implode("\n", array(
-            'outbound_proxy_host = "site.com"',
-            'outbound_proxy_port = "8080"'
-        ));
-        file_put_contents($file_config, $data);
-        $store = Store::createFromFile($file_config);
-        unlink($file_config);
-        $this->assertEquals('site.com:8080', $store->outboundProxy());
-    }
-
     public function testNoHreflangLangs()
     {
         $file_config = dirname(__FILE__) . '/test_config.ini';


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-2444
### Comments
Support connecting to wovn servers via HTTP proxy. Only supported for curl.

Didn't test with an actual proxy server but curl reported this error so the setting is being applied correctly
```
curl_error($curl_session)
"Failed to connect to proxy.com port 7979: Connection timed out"
```
### Release comments (new feature)
