### PR TITLE
refactor: [ST-2960] Fix deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,27 @@ jobs:
           paths:
             - ./vendor
       - run: ./vendor/bin/phpcs
+  test_php83:
+    <<: *defaults
+    steps:
+      - common-steps
+      - run: scripts/run_phpunit_tests.sh php:8.3-apache
+      - run: scripts/run_integration_tests.sh php:8.3-apache
+      - store-steps
+  test_php82:
+    <<: *defaults
+    steps:
+      - common-steps
+      - run: scripts/run_phpunit_tests.sh php:8.2-apache
+      - run: scripts/run_integration_tests.sh php:8.2-apache
+      - store-steps
+  test_php81:
+    <<: *defaults
+    steps:
+      - common-steps
+      - run: scripts/run_phpunit_tests.sh php:8.1-apache
+      - run: scripts/run_integration_tests.sh php:8.1-apache
+      - store-steps
   test_php80:
     <<: *defaults
     steps:
@@ -121,6 +142,9 @@ workflows:
   build:
     jobs:
       - build
+      - test_php83
+      - test_php82
+      - test_php81
       - test_php80
       - test_php74
       - test_php73

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ commands:
           at: ~/project
       - setup_remote_docker:
           docker_layer_caching: true
+          version: docker25
   store-steps:
     steps:
       - store_test_results:

--- a/scripts/run_phpunit_tests.sh
+++ b/scripts/run_phpunit_tests.sh
@@ -24,10 +24,10 @@ docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "php --version"
 
 if [[ "${DOCKER_IMAGE}" =~ ^.*php:?(7\.[1-9]|8\.[0-9]).*$ ]]; then
     # Convert test to support PHP8 syntax
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function setUp\(\)/function setUp(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function setUpBeforeClass\(\)/function setUpBeforeClass(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function tearDown\(\)/function tearDown(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function tearDownAfterClass\(\)/function tearDownAfterClass(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function setUp()/function setUp(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function setUpBeforeClass()/function setUpBeforeClass(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function tearDown()/function tearDown(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function tearDownAfterClass()/function tearDownAfterClass(): void/g'"
 fi
 
 # Set up modules

--- a/scripts/run_phpunit_tests.sh
+++ b/scripts/run_phpunit_tests.sh
@@ -24,10 +24,10 @@ docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "php --version"
 
 if [[ "${DOCKER_IMAGE}" =~ ^.*php:?(7\.[1-9]|8\.[0-9]).*$ ]]; then
     # Convert test to support PHP8 syntax
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function setUp(.*)$/function setUp(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function setUpBeforeClass(.*)$/function setUpBeforeClass(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function tearDown(.*)$/function tearDown(): void/g'"
-    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name \"*.php\" -print0 | xargs -0 sed -i 's/function tearDownAfterClass(.*)$/function tearDownAfterClass(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function setUp\(\)/function setUp(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function setUpBeforeClass\(\)/function setUpBeforeClass(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function tearDown\(\)/function tearDown(): void/g'"
+    docker exec ${APACHE_CONTAINER_ID} /bin/bash -c "find ${WORK_DIR}/test -type f -name '*.php' -print0 | xargs -0 sed -i -r 's/function tearDownAfterClass\(\)/function tearDownAfterClass(): void/g'"
 fi
 
 # Set up modules

--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.24.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.24.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
+++ b/src/wovnio/utils/request_handlers/AbstractRequestHandler.php
@@ -5,6 +5,8 @@ use \Wovnio\Wovnphp\Logger;
 
 abstract class AbstractRequestHandler
 {
+    protected $store;
+
     abstract protected function post($url, $request_headers, $query, $timeout);
 
     public static function available()

--- a/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
+++ b/src/wovnio/wovnphp/custom_domain/CustomDomainLangUrlHandler.php
@@ -17,10 +17,10 @@ class CustomDomainLangUrlHandler
             $newHostAndPath = $newLangCustomDomain->getHostAndPathWithoutTrailingSlash();
             $regex = '@'.
                 '^(.*://|//)?'. // 1. schema
-                "(${currentHostAndPath})". // 2. host and path
+                "({$currentHostAndPath})". // 2. host and path
                 '((?:/|\?|#).*)?$' . // 3: other
                 '@';
-            return preg_replace($regex, '${1}' . "${newHostAndPath}" . '${3}', $absoluteUrl);
+            return preg_replace($regex, '${1}' . "{$newHostAndPath}" . '${3}', $absoluteUrl);
         }
         return $absoluteUrl;
     }

--- a/test/integration/CookieLangTest.php
+++ b/test/integration/CookieLangTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\TestCase;
 
 class CookieLangTest extends TestCase
 {
+    private $sourceDir;
+    private $docRoot;
+
     protected function setUp()
     {
         $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');

--- a/test/integration/InsertHreflangsTest.php
+++ b/test/integration/InsertHreflangsTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class InsertHreflangsTest extends TestCase
 {
+    private $sourceDir;
+    private $docRoot;
+
     protected function setUp()
     {
         $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');

--- a/test/integration/SSIWovnIndexSampleTest.php
+++ b/test/integration/SSIWovnIndexSampleTest.php
@@ -5,6 +5,10 @@ use PHPUnit\Framework\TestCase;
 
 class SSIWovnIndexSampleTest extends TestCase
 {
+    private $baseDir;
+    private $workspace;
+    private $paths;
+
     protected function setUp()
     {
         $this->baseDir = getcwd();
@@ -107,7 +111,7 @@ CONTENT;
         $_SERVER['SERVER_NAME'] = 'wovn.php';
         $_SERVER['REQUEST_URI'] = $request_uri;
         $_GET = $queryParams;
-        
+
         ob_start();
         include('wovn_index.php');
         return ob_get_clean();

--- a/test/integration/UrlCustomDomainPatternTest.php
+++ b/test/integration/UrlCustomDomainPatternTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 class UrlCustomDomainPatternTest extends TestCase
 {
     private static $orgHostFile;
+    private $sourceDir;
+    private $docRoot;
 
     public static function setUpBeforeClass()
     {

--- a/test/integration/UrlPathPatternTest.php
+++ b/test/integration/UrlPathPatternTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class UrlPathPatternTest extends TestCase
 {
+    private $sourceDir;
+    private $docRoot;
+
     protected function setUp()
     {
         $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');

--- a/test/integration/UrlQueryPatternTest.php
+++ b/test/integration/UrlQueryPatternTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class UrlQueryPatternTest extends TestCase
 {
+    private $sourceDir;
+    private $docRoot;
+
     protected function setUp()
     {
         $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');

--- a/test/integration/UrlSubdomainPatternTest.php
+++ b/test/integration/UrlSubdomainPatternTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 class UrlSubdomainPatternTest extends TestCase
 {
     private static $orgHostFile;
+    private $sourceDir;
+    private $docRoot;
 
     public static function setUpBeforeClass()
     {

--- a/test/integration/WovnIndexSampleApacheTest.php
+++ b/test/integration/WovnIndexSampleApacheTest.php
@@ -202,9 +202,9 @@ EXPECTED;
             if (is_array($value)) {
                 foreach ($value as $key => $v) {
                     if (is_string($key)) {
-                        $contents[] = "${name}[$key] = $v";
+                        $contents[] = "{$name}[$key] = $v";
                     } else {
-                        $contents[] = "${name}[] = $v";
+                        $contents[] = "{$name}[] = $v";
                     }
                 }
             } else {

--- a/test/integration/WovnIndexSampleApacheTest.php
+++ b/test/integration/WovnIndexSampleApacheTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 class WovnIndexSampleApacheTest extends TestCase
 {
+    private $sourceDir;
+    private $docRoot;
+
     protected function setUp()
     {
         $this->sourceDir  = realpath(dirname(__FILE__) . '/../..');

--- a/test/integration/WovnIndexSampleTest.php
+++ b/test/integration/WovnIndexSampleTest.php
@@ -10,6 +10,10 @@ use PHPUnit\Framework\TestCase;
 
 class WovnIndexSampleTest extends TestCase
 {
+    private $baseDir;
+    private $workspace;
+    private $paths;
+
     protected function setUp()
     {
         $this->baseDir = getcwd();

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -546,7 +546,7 @@ class HeadersTest extends TestCase
             list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
 
             $this->assertEquals('custom_domain', $store->settings['url_pattern_name']);
-            $this->assertEquals($expectedLangCode, $headers->urlLanguage(), "env -> [" . json_encode($env) . "] | lang -> [${expectedLangCode}]");
+            $this->assertEquals($expectedLangCode, $headers->urlLanguage(), "env -> [" . json_encode($env) . "] | lang -> [{$expectedLangCode}]");
         };
     }
 

--- a/test/unit/StoreTest.php
+++ b/test/unit/StoreTest.php
@@ -28,8 +28,6 @@ class StoreTest extends TestCase
         $mockObject = $builder->getMock();
         if (method_exists($this, 'registerMockObject')) {
             $this->registerMockObject($mockObject);
-        } else {
-            $this->mockObjects[] = $mockObject;
         }
         return $mockObject;
     }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

https://wovnio.atlassian.net/browse/ST-2960

Changes:
- Fixes the following deprecations:
  - "Deprecate ${} string interpolation" (see [PHP RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation))
  - "Deprecate dynamic properties" (see [PHP RFC](https://wiki.php.net/rfc/deprecate_dynamic_properties))
- Adds tests for PHP 8.1 to 8.3

### Comments

### Release comments (new feature)
