### PR TITLE
fix: [ST-3186] use_cookie_lang now redirects for default + target lang cookies

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.24.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.24.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -382,7 +382,7 @@ class Headers
         $requestLang = $this->requestLang();
         $cookieLang = $this->cookieLang->getCookieLang();
 
-        return $cookieLang && ($requestLang !== $cookieLang) && ($requestLang === $this->store->defaultLang());
+        return $cookieLang && ($requestLang !== $cookieLang);
     }
 
     public function isSearchEngineBot()

--- a/test/integration/CookieLangTest.php
+++ b/test/integration/CookieLangTest.php
@@ -100,6 +100,6 @@ class CookieLangTest extends TestCase
         $result = TestUtils::fetchURL('http://localhost/ja/index.html', null, array('wovn_selected_lang' => 'en'));
 
         self::assertEquals(302, $result->statusCode);
-        self::assertEquals('http://localhost/index.html', $result->sensibleHeaders['Location']);
+        self::assertEquals('http://localhost/en/index.html', $result->sensibleHeaders['Location']);
     }
 }

--- a/test/integration/CookieLangTest.php
+++ b/test/integration/CookieLangTest.php
@@ -71,7 +71,7 @@ class CookieLangTest extends TestCase
         self::assertEquals('http://localhost/ja/index.html', $result->sensibleHeaders['Location']);
     }
 
-    public function testRequestToTargetLangWithCookieShouldNotRedirect()
+    public function testRequestToTargetLangWithCookieShouldRedirect()
     {
         copy("{$this->sourceDir}/wovn_index_sample.php", "{$this->docRoot}/wovn_index.php");
         TestUtils::writeFile("{$this->docRoot}/index.html", '<html><head></head><body>test</body></html>');
@@ -83,10 +83,11 @@ class CookieLangTest extends TestCase
         ));
         $result = TestUtils::fetchURL('http://localhost/zh-Hant-HK/index.html', null, array('wovn_selected_lang' => 'ja'));
 
-        self::assertEquals(200, $result->statusCode);
+        self::assertEquals(302, $result->statusCode);
+        self::assertEquals('http://localhost/ja/index.html', $result->sensibleHeaders['Location']);
     }
 
-    public function testRequestToTargetLangWithDefaultCookieShouldNotRedirect()
+    public function testRequestToTargetLangWithDefaultCookieShouldRedirect()
     {
         copy("{$this->sourceDir}/wovn_index_sample.php", "{$this->docRoot}/wovn_index.php");
         TestUtils::writeFile("{$this->docRoot}/index.html", '<html><head></head><body>test</body></html>');
@@ -98,6 +99,7 @@ class CookieLangTest extends TestCase
         ));
         $result = TestUtils::fetchURL('http://localhost/ja/index.html', null, array('wovn_selected_lang' => 'en'));
 
-        self::assertEquals(200, $result->statusCode);
+        self::assertEquals(302, $result->statusCode);
+        self::assertEquals('http://localhost/index.html', $result->sensibleHeaders['Location']);
     }
 }

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -1603,7 +1603,7 @@ class HeadersTest extends TestCase
     public function testRequestToTargetLangWithTargetCookieQueryPatternShouldNotRedirect()
     {
         list($store, $headers) = $this->getHeaderStoreQueryPattern('ja', 'fr');
-        $this->assertEquals(false, $headers->shouldRedirect());
+        $this->assertEquals(true, $headers->shouldRedirect());
     }
 
     public function testRequestToSameLangWithCookieQueryPatternShouldNotRedirect()
@@ -1627,7 +1627,7 @@ class HeadersTest extends TestCase
     public function testRequestToTargetLangWithTargetCookiePathPatternShouldNotRedirect()
     {
         list($store, $headers) = $this->getHeaderStorePathPattern('ja', 'fr');
-        $this->assertEquals(false, $headers->shouldRedirect());
+        $this->assertEquals(true, $headers->shouldRedirect());
     }
 
     public function testRequestToSameLangWithCookiePathPatternShouldNotRedirect()


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)
https://wovnio.atlassian.net/browse/ST-3186
equivalent of https://github.com/WOVNio/proxy/pull/158/

We will now prefer the cookie language over the request language in all cases. If you have a language cookie different to the request lang, and this feature turned on, we will redirect to it.
### Comments

### Release comments (new feature)
