### PR TITLE
fix: handle multi-value X-Forwarded-Host header

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.28.0';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.28.1';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/Headers.php
+++ b/src/wovnio/wovnphp/Headers.php
@@ -49,7 +49,7 @@ class Headers
             }
         }
         if ($store->settings['use_proxy'] && isset($env['HTTP_X_FORWARDED_HOST'])) {
-            $this->originalHost = $env['HTTP_X_FORWARDED_HOST'];
+            $this->originalHost = self::getFirstValueFromHeader($env['HTTP_X_FORWARDED_HOST']);
         } else {
             $this->originalHost = $env['HTTP_HOST'];
         }
@@ -118,7 +118,7 @@ class Headers
     {
         if ($this->urlLang === null) {
             if ($this->store->settings['use_proxy'] && isset($this->env['HTTP_X_FORWARDED_HOST'])) {
-                $server_name = $this->env['HTTP_X_FORWARDED_HOST'];
+                $server_name = self::getFirstValueFromHeader($this->env['HTTP_X_FORWARDED_HOST']);
             } else {
                 $server_name = $this->env['HTTP_HOST'];
             }
@@ -223,7 +223,7 @@ class Headers
     private function removeLangFromHost()
     {
         if ($this->store->settings['use_proxy'] && isset($this->env['HTTP_X_FORWARDED_HOST'])) {
-            $this->env['HTTP_X_FORWARDED_HOST'] = $this->removeLang($this->env['HTTP_X_FORWARDED_HOST']);
+            $this->env['HTTP_X_FORWARDED_HOST'] = $this->removeLang(self::getFirstValueFromHeader($this->env['HTTP_X_FORWARDED_HOST']));
         }
         $this->env['HTTP_HOST'] = $this->removeLang($this->env['HTTP_HOST']);
         $this->env['SERVER_NAME'] = $this->removeLang($this->env['SERVER_NAME']);
@@ -403,5 +403,17 @@ class Headers
             }
         }
         return false;
+    }
+
+    // X-Forwarded-Host can contain multiple comma-separated values when
+    // the request passes through more than one proxy (RFC 7230 §3.2.2).
+    // We only need the original (leftmost) host.
+    private static function getFirstValueFromHeader($value)
+    {
+        $commaPos = strpos($value, ',');
+        if ($commaPos !== false) {
+            return trim(substr($value, 0, $commaPos));
+        }
+        return $value;
     }
 }

--- a/test/unit/HeadersTest.php
+++ b/test/unit/HeadersTest.php
@@ -1665,4 +1665,82 @@ class HeadersTest extends TestCase
 
         $this->assertEquals(true, $headers->isSearchEngineBot());
     }
+
+    public function testMultiValueXForwardedHostUsesFirstValue()
+    {
+        $settings = array('use_proxy' => 1, 'url_pattern_name' => 'path');
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => 'www.example.com, www.example.com',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REQUEST_URI' => '/en/page'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('www.example.com', $headers->originalHost);
+        $this->assertEquals('www.example.com', $headers->host);
+        $this->assertEquals('https://www.example.com/page', $headers->urlKeepTrailingSlash);
+    }
+
+    public function testMultiValueXForwardedHostWithSpaces()
+    {
+        $settings = array('use_proxy' => 1, 'url_pattern_name' => 'path');
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => '  www.example.com , proxy.internal ',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REQUEST_URI' => '/en/page'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('www.example.com', $headers->originalHost);
+    }
+
+    public function testSingleValueXForwardedHostUnchanged()
+    {
+        $settings = array('use_proxy' => 1, 'url_pattern_name' => 'path');
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => 'www.example.com',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REQUEST_URI' => '/en/page'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('www.example.com', $headers->originalHost);
+        $this->assertEquals('www.example.com', $headers->host);
+    }
+
+    public function testMultiValueXForwardedHostWithSubdomainPattern()
+    {
+        $settings = array(
+            'use_proxy' => 1,
+            'url_pattern_name' => 'subdomain',
+            'supported_langs' => array('en', 'ja')
+        );
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => 'ja.example.com, proxy1.internal',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'REQUEST_URI' => '/page'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('ja.example.com', $headers->originalHost);
+        $this->assertEquals('example.com', $headers->host);
+        $this->assertEquals('ja', $headers->urlLanguage());
+    }
+
+    public function testMultiValueXForwardedHostUrlLanguageWithPath()
+    {
+        $settings = array(
+            'use_proxy' => 1,
+            'url_pattern_name' => 'path',
+            'supported_langs' => array('en', 'ja')
+        );
+        $env = array(
+            'HTTP_X_FORWARDED_HOST' => 'www.example.com, www.example.com',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'HTTP_X_FORWARDED_REQUEST_URI' => '/ja/page'
+        );
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default', $settings, $env);
+
+        $this->assertEquals('ja', $headers->urlLanguage());
+    }
 }


### PR DESCRIPTION
## Summary

- When multiple proxies are in the request chain, `X-Forwarded-Host` contains comma-separated values per RFC 7230 §3.2.2 (e.g. `www.example.com, www.example.com`)
- WOVN.php was using the raw header value as the hostname, producing malformed URLs like `https://host1, host2/path`
- This caused html-swapper's upstream API to return HTTP 406, surfaced as Rollbar html-swapper#717
- Fix: extract only the first (leftmost/original) host value before use

## Root cause

A customer with multiple proxy hops has the host duplicated in `X-Forwarded-Host`. This is valid HTTP behavior — we just weren't handling it.

## Test plan

- [x] Added tests for multi-value `X-Forwarded-Host` (comma-separated, with spaces)
- [x] Added test for single-value (no regression)
- [x] Added tests for subdomain and path URL patterns with multi-value header
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)