### PR TITLE
chore: bump version to 1.29.0

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.28.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.29.0';
     define('WOVN_PHP_VERSION', $version);
 }


### PR DESCRIPTION
### Purpose/goal of PR (Issue #)

In https://github.com/WOVNio/WOVN.php/pull/211, I set the version to 1.28.1,
but I now think it makes more sense to set it 1.29.0 instead, as it's not the fix for 1.28.0.

### Comments

### Release comments (new feature)
