### PR TITLE
fix: undefined $marker in the no-request-handler branch of API::translate

### DIFF
--- a/src/version.php
+++ b/src/version.php
@@ -3,6 +3,6 @@ if (!defined('WOVN_PHP_NAME')) {
     define('WOVN_PHP_NAME', 'WOVN.php');
 }
 if (!defined('WOVN_PHP_VERSION')) {
-    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.28.1';
+    $version = isset($_ENV['WOVN_ENV']) && $_ENV['WOVN_ENV'] === 'development' ? 'VERSION' : '1.28.2';
     define('WOVN_PHP_VERSION', $version);
 }

--- a/src/wovnio/wovnphp/API.php
+++ b/src/wovnio/wovnphp/API.php
@@ -96,7 +96,7 @@ class API
         try {
             $request_handler = RequestHandlerFactory::getBestAvailableRequestHandler($store);
             if ($request_handler === null) {
-                return $marker->revert($converted_html);
+                return $converter->revertMarkers($converted_html);
             }
             $api_url = self::url($store, $headers, $converted_html, $request_options);
             list($response, $headers, $error) = $request_handler->sendRequest('POST', $api_url, $data, $timeout);

--- a/test/helpers/RecordingLogger.php
+++ b/test/helpers/RecordingLogger.php
@@ -1,0 +1,35 @@
+<?php
+namespace Wovnio\Wovnphp;
+
+require_once 'src/wovnio/wovnphp/Logger.php';
+
+/**
+ * Test logger that records the messages passed to `error` so tests can assert
+ * whether the error path was taken. Other levels are swallowed.
+ */
+class RecordingLogger extends Logger
+{
+    public $errors = array();
+
+    public function __construct()
+    {
+        parent::__construct('RecordingLogger');
+    }
+
+    public function error($message, $context = array())
+    {
+        $this->errors[] = $message;
+    }
+
+    public function warning($message, $context = array())
+    {
+    }
+
+    public function info($message, $context = array())
+    {
+    }
+
+    public function debug($message, $context = array())
+    {
+    }
+}

--- a/test/unit/APITest.php
+++ b/test/unit/APITest.php
@@ -3,6 +3,9 @@ namespace Wovnio\Wovnphp\Tests\Unit;
 
 require_once 'test/helpers/StoreAndHeadersFactory.php';
 require_once 'test/helpers/RequestHandlerMock.php';
+require_once 'test/helpers/CurlMock.php';
+require_once 'test/helpers/FileGetContentsMock.php';
+require_once 'test/helpers/RecordingLogger.php';
 
 require_once 'src/wovnio/wovnphp/API.php';
 require_once 'src/wovnio/wovnphp/Utils.php';
@@ -23,6 +26,8 @@ require_once 'src/wovnio/modified_vendor/SimpleHtmlDom.php';
 use Wovnio\Test\Helpers\StoreAndHeadersFactory;
 
 use Wovnio\Wovnphp\API;
+use Wovnio\Wovnphp\Logger;
+use Wovnio\Wovnphp\RecordingLogger;
 use Wovnio\Wovnphp\Utils;
 use Wovnio\Wovnphp\RequestOptions;
 use Wovnio\Html\HtmlConverter;
@@ -397,6 +402,40 @@ class APITest extends TestCase
         $this->assertEquals(1, count($mock->arguments));
         $expected_result = '<html lang="en"><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><link rel="alternate" hreflang="x-default" href="http://my-site.com/" data-wovn="true"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async></script></head><body><h1>en</h1></body></html>';
         $this->assertEquals($expected_result, $result, "should return contents with fallback");
+    }
+
+    public function testTranslateWhenNoRequestHandlerIsAvailable()
+    {
+        // Force RequestHandlerFactory to return null by making both cURL and
+        // file_get_contents (allow_url_fopen) unavailable. This exercises the
+        // `$request_handler === null` branch of API::translate, which must
+        // fall back to the snippet-inserted content without raising an error.
+        \Wovnio\Utils\RequestHandlers\mockCurl(false, array(), array());
+        \Wovnio\Utils\RequestHandlers\mockFileGetContents(false);
+        RequestHandlerFactory::setInstance(null);
+
+        list($store, $headers) = StoreAndHeadersFactory::fromFixture('default');
+        $original_html = '<html><head></head><body><h1>en</h1></body></html>';
+        $request_options = new RequestOptions(array(), false);
+
+        // Store construction resets the global logger, so install the recording
+        // logger after the store is built.
+        $default_logger = Logger::get();
+        $logger = new RecordingLogger();
+        Logger::set($logger);
+
+        $result = API::translate($store, $headers, $original_html, $request_options);
+
+        \Wovnio\Utils\RequestHandlers\restoreCurl();
+        \Wovnio\Utils\RequestHandlers\restoreFileGetContents();
+        Logger::set($default_logger);
+
+        $expected_result = '<html lang="en"><head><link rel="alternate" hreflang="en" href="http://my-site.com/"><link rel="alternate" hreflang="x-default" href="http://my-site.com/" data-wovn="true"><script src="//j.wovn.io/1" data-wovnio="key=123456&amp;backend=true&amp;currentLang=en&amp;defaultLang=en&amp;urlPattern=query&amp;langCodeAliases=[]&amp;langParamName=wovn" data-wovnio-info="version=WOVN.php_VERSION" data-wovnio-type="fallback_snippet" async></script></head><body><h1>en</h1></body></html>';
+        $this->assertEquals($expected_result, $result, 'should return snippet-inserted fallback content when no request handler is available');
+        // The no-handler branch must return directly. Before the fix it called
+        // an undefined `$marker`, whose error was swallowed by the surrounding
+        // catch block and logged as a failure.
+        $this->assertEquals(array(), $logger->errors, 'should not log any error in the no-handler fallback path');
     }
 
     public function testTranslateWithSearchEngineBot()


### PR DESCRIPTION
In `API::translate()` (`src/wovnio/wovnphp/API.php`), the branch taken when no request handler is available references an undefined variable:

```php
$request_handler = RequestHandlerFactory::getBestAvailableRequestHandler($store);
if ($request_handler === null) {
    return $marker->revert($converted_html);   // $marker is never defined in this method
}
```

`$marker` is not defined anywhere in `translate()` (it appears only on this line). Every other return in the method uses `$converter->revertMarkers($converted_html)` (the `HtmlConverter` created at the top of the method). So this line is both an undefined variable and the wrong method name.

`getBestAvailableRequestHandler()` returns `null` when neither request handler is available (e.g. the cURL extension is missing and `allow_url_fopen` is off). In that situation, instead of the intended graceful degradation (returning the page untranslated), calling `->revert()` on the undefined `$marker` throws an `\Error`. The surrounding `catch (\Exception $e)` does not catch `\Error`, so it becomes an uncaught fatal — and since WOVN.php wraps the whole page output, every request on such a server returns a 500 rather than the untranslated page.

Fixed by calling `$converter->revertMarkers($converted_html)`, matching the other branches.